### PR TITLE
Ergebnisdaten Xsd-Elemete sortiert

### DIFF
--- a/Entwicklung/Cindy/HUSST_Ergebnisdaten_Cindy.xsd
+++ b/Entwicklung/Cindy/HUSST_Ergebnisdaten_Cindy.xsd
@@ -16,17 +16,1626 @@
 		</documentation>
 	</annotation>
 
-	<complexType name="Warenkorb_Type">
+  <complexType name="Any_Type">
+    <choice>
+      <element name="StringData" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="BinaryData" type="base64Binary" maxOccurs="1" minOccurs="0"/>
+    </choice>
+  </complexType>
+
+  <complexType name="Ausgabeabschnitt_Type">
+    <annotation>
+      <documentation>
+        Definiert einen Papierabschnitt mit seiner Startnummer
+        und der Anzahl seiner Barcodeabschnitte oder Abschnittzähler. Die Startnummer
+        ist immer die kleinste Nummer des gelesenen Abschnittes,
+        egal in welche Richtung die Nummerierung der Rolle geht.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="StartNr" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>Startnummer des Abschnittzählers, z.B. Barcode oder anfängliche Rollennummer.</documentation>
+        </annotation>
+      </element>
+      <element name="Anzahl" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Anzahl der Abschnittzähler, z.B. Barcodes</documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="Typ" type="husst:AusgabeabschnittTyp_Type" use="required">
+      <annotation>
+        <documentation>Der Typ des Papierdokumentes</documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Barbezahlung_Type">
+    <sequence>
+      <element name="Einnahme" type="husst:Betrag_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Rueckgabe" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Bargeldbilanz_Type">
+    <annotation>
+      <documentation>
+        Für jede vorkommende Währung werden hier die Bilanzen
+        über den Dienst, der bei Automaten gleiche mit der Schicht ist,
+        aufgeführt. Die zugehörigen Bargeld-Einnahmen finden sich in der
+        Kassenliste.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="Anfangsbestand" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="1"/>
+      <element name="Zufuehrungen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Entnahmen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Fehleinnahmen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Kassenentnahmen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Endbestand" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Beleg_Type">
+    <sequence>
+      <element name="BelegNr" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Laufende Aufdrucknummer auf einem Papierdokument oder gespeicherte
+            Folgenummer
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Abschnitt" type="husst:Ausgabeabschnitt_Type" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Zugehörige, unveränderliche Dokumentmerkmale. (Abschnittzähler oder rückseitiger Barcode)</documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="Typ" type="husst:BelegTyp_Type" use="required"/>
+  </complexType>
+
+  <complexType name="Belegkasse_Type">
+    <sequence>
+      <element name="Betrag" type="husst:Betrag_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Hier kann der Gesamtbetrag der vereinnahmten
+            Belege eingetragen werden
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Gutschrift" type="husst:Tarifprodukt_Type" minOccurs="0" maxOccurs="1"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="Typ" type="husst:BelegkasseTyp_Type" use="required"/>
+    <attribute name="Anzahl" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="Belegkassenliste_Type">
+    <sequence>
+      <element name="BelegKasse" type="husst:Belegkasse_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Betrag_Type">
+    <sequence>
+      <element name="Waehrung" type="husst:Waehrung_Type"/>
+      <element name="Betrag" type="int">
+        <annotation>
+          <documentation>
+            Betrag in kleinsten Währungseinheiten (z.B. Euro-Cent)
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+
+  <complexType name="Datensatz_Type">
+    <choice>
+      <element name="Schichtbeginn" type="husst:Schichtbeginn_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Schichtabschluss" type="husst:Schichtabschluss_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Pruefbeginn" type="husst:Pruefbeginn_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Pruefabschluss" type="husst:Pruefabschluss_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Komponentenliste" type="husst:Komponentenliste_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Meldung" type="husst:Meldung_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Ausgabeabschnitt" type="husst:Ausgabeabschnitt_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Transaktionsdaten" type="husst:Transaktionsdaten_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Fahrtverlauf" type="husst:Fahrtverlauf_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Dienstbeginn" type="husst:Dienstbeginn_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Dienstende" type="husst:Dienstende_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Kontrolldaten" type="husst:Kontrolldaten_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Geldbehaelterliste" type="husst:Geldbehaelterliste_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Warenkorb" type="husst:Warenkorb_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="EBEErfassung" type="husst:EBEErfassung_Type" maxOccurs="1" minOccurs="1"/>
+    </choice>
+    <attribute name="Zeitpunkt" type="dateTime" use="required">
+      <annotation>
+        <documentation>
+          Der jeweilge Zeitpunkt der Generierung des
+          Datenatzes.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="DsNr" type="int" use="required">
+      <annotation>
+        <documentation>
+          Eine fortlaufende ununterbrochene Nummer innerhalb
+          der Schicht. Die '0' sollte ausgenommen werden.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Dienstbeginn_Type">
+    <sequence>
+      <element name="Vertriebsstelle" type="husst:Vertriebsstelle_Type" minOccurs="1" maxOccurs="unbounded">
+        <annotation>
+          <documentation>
+            Der Dienstbeginn kann gleichzeitig auf mehrere
+            Vertriebsstellen bezogen sein. Hiermit besteht
+            beispielsweise die Möglichkeit geichzeitig auf
+            den Verkäufer und die Verkaufsstelle zu
+            beziehen.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="DienstPlanNr" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Die laufende Bezeichnung des Dienstplans des
+            Gerätebedieners.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required">
+      <annotation>
+        <documentation>
+          Diese Dienstnummer enstpricht der den Anwendern
+          bekannte Dienstnummer.
+          In der Regel wird nach dieser Nummer ausgewertet 
+          und die Nummer wird auf Belege aufgedruckt.
+          Die Dienstnummer ist mindestens für jede Schicht eindeutig. 
+          Eine Schicht kann viele Dienste enthalten.
+          Die Dienstnummer sollte inkrementierend aufsteigen und nie '0' sein.
+
+          Achtung: Schichtnummer vs. Dienstnummer:
+          Innerhalb einer Schicht können mehrere Dienste
+          auch gleichzeitig ablaufen.
+          Kein Dienst überlappt zeitlich eine Schichtgrenze. 
+          Dienste sind in der Regel Personen-(Konten) oder
+          Geräte-(Konten) zugeordnet.
+          Schichten sind nur ein Behälter für
+          Dienste und sonstige Informationen, die
+          keinem Dienst zugeordnet sind.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Dienstende_Type">
+    <sequence>
+      <element name="Vertriebsstelle" type="husst:Vertriebsstelle_Type" maxOccurs="unbounded" minOccurs="1"/>
+      <element name="Beleg" type="husst:Beleg_Type" minOccurs="0" maxOccurs="unbounded"/>
+      <element name="Kassenliste" type="husst:Kassenliste_Type" minOccurs="1" maxOccurs="1"/>
+      <element name="Belegkassenliste" type="husst:Belegkassenliste_Type" minOccurs="1" maxOccurs="1"/>
+      <element name="Bargeldbilanz" type="husst:Bargeldbilanz_Type" minOccurs="0" maxOccurs="1"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="DynAttribut_Subtype">
+    <annotation>
+      <documentation>
+        Der Subtyp DynAttribut_Subtype dient der Definition von
+        dynamischen Attributen als mögliche Erweiterung für die
+        Xml-Darstellung der Daten. Der Subtyp wird nicht 1:1 für
+        eine Abbildung auf ein relationales Datenbankmodell
+        verwendet.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="Name" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Wert" type="string" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="EBEErfassung_Type">
+    <sequence>
+      <element name="BezugsNr" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Eine eindeitige ID dieses EBE-Vorgangs, es
+            könnte bei Verkaufsgeräten die UID sein, bei
+            Nacherfassung muss die ID vom Bediener
+            versorgt werden.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="EBEVorgang" type="husst:EBEVorgang_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Merkmale" type="husst:EBEMerkmale_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Kundendaten" type="husst:Kundendaten_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Verfolgung" type="husst:Verfolgung_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="EBEMerkmale_Type">
+    <sequence>
+      <element name="Ort" type="husst:Transaktionsort_Type" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eine Erfassung des Vorgangsorts.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="VorfallsOrtNotiz" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eine textuelle Beschreibung des Vorfallsorts.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="KomfortKlasse" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="Fahrausweisart" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Wenn ein Fahrausweis vorgezeigt wurde, welcher Art
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrausweisNr" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Die Nummer (laufende Nummer) des Fahrausweises
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrausweisEingezogen" type="boolean" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Wird auf true gesetzt, wenn der Fahrausweis	eingezogen wurde.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrausweisAbholung" type="date" maxOccurs="1" minOccurs="0"/>
+      <element name="Bearbeitungsstelle" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="EinstiegsHaltestelle" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Die IBNR</documentation>
+        </annotation>
+      </element>
+      <element name="EinstiegNotiz" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eine textuelle Beschreibung zum Einstieg
+          </documentation>
+        </annotation>
+      </element>
+      <element name="ZielHaltestelle" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Die IBNR</documentation>
+        </annotation>
+      </element>
+      <element name="ZielNotiz" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eine textuelle Beschreibung zum Fahrtziel bzw. Ausstieg
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Codierung" type="husst:Codierung_Type" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Eine Codierung zur Angabe des Grunds zum EBE-Fall
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Sitzplatz" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Ein Hinweis, wo der EBE-Fall angetroffen wurde
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Verhalten" type="string" maxOccurs="unbounded" minOccurs="0">
+        <annotation>
+          <documentation>
+            Bemerkungen zu Verhalten des EBE-Falls.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Polizei" type="husst:Polizei_Type" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Wenn Polizei hinzugezogen wurde, von welchem Revier.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Linie" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="Kurs" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="Verbundkennung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+
+
+  <complexType name="EBEVorgang_Type">
+    <sequence>
+      <element name="Typ" type="husst:VorgangsTyp_Type" maxOccurs="unbounded" minOccurs="1"/>
+      <element name="Beanstandung" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Entspricht der vorgegebenen Codierung z.B. der
+            Bahn, in der Regel eine zweistellige Ziffer.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Begruendung" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Der Grund der Beanstandung (zB. nicht lesbar, vermutlich verfälscht, Tarif ungültig, ohne Kundenkarte etc.)
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Forderung" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Referenzbetrag" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="EinsatzTyp_Type">
+    <sequence>
+      <element name="Name" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Der Name ist ein beliebiger, sprechender Name des
+            Einsatztyps (z.B. Vorverkauf, Bereich Hamburg Mitte).
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+    <attribute name="Nr" type="int">
+      <annotation>
+        <documentation>
+          Einsatztypen unterscheiden im Gegensatz zu Geräten den jeweiligen Einsatz des Gerätes.
+          So kann ein gleiches technisches Gerät sowohl mobil als auch
+          stationär mit unterschiedlichen	Ausprägungen betrieben werden.
+
+          Die Einsatztypennummer entspricht der dem Anwender bekannten Einsatztypennummer.
+          Der Standard-Einsatztyp	ist '1'.
+
+          Die Einsatztypennummer ist nur zusammen mit der Angabe
+          eines Mandanten	eindeutig.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="Mandant" type="int">
+      <annotation>
+        <documentation>
+          Die Einsatztypennummer ist nur zusammen mit einem
+          zugeordneten Mandant eindeutig.
+          Der Standard-Mandant ist '1'.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Fahrtverlauf_Type">
+    <annotation>
+      <documentation>Diese Datensätze beinhalten, abweichend von anderen Datensätzen,  Information aus betrieblichen VDV452 Daten.</documentation>
+    </annotation>
+    <sequence>
+      <element name="Betrieb" type="husst:INT4" minOccurs="1" maxOccurs="1">
+        <annotation>
+          <documentation>
+            REC_FRT.BETRIEB aus VDV bei Mandantensystemen, sonst 0.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrzeugNr" type="husst:INT4" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Nach VDV FAHRZEUG.FZG_NR
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrzeugUnr" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Nummer des Unternehmens, dem das Fahrzeug	gehört. FAHRZEUG.ABK_UNTERNEHMEN
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrerNr" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Nch VDV: PERSONAL.FAHRER_NR</documentation>
+        </annotation>
+      </element>
+      <element name="FahrerUnr" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Nach VDV: PERSONAL.ABK_UNTERNEHMEN -> TEILNEHMER.UNTERNEHMEN
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrtID" type="husst:INT4" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Fahrtnummer der Fahrt laut VDV REC_FRT.FRT_ID
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Fahrt" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Optionale Kennung der Fahrt als Text.</documentation>
+        </annotation>
+      </element>
+      <element name="LinieID" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Nach VDV: Aus der Tabelle REC_LID.LI_NR
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Linie" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Optionale Linieninformation als Text. Optional REC_LID.LIDNAME oder REC_LID.LI_KUERZEL</documentation>
+        </annotation>
+      </element>
+      <element name="Richtung" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Nach VDV: REC_LID.LI_RI_NR
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrplanLage" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Fahrplanlage in Sekunden, negative Werte für Verfrühung.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="OrtTyp" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Nach VDV: REC_ORT.ONR_TYP_NR</documentation>
+        </annotation>
+      </element>
+      <element name="OrtNr" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Haltepunktnummer nach VDV: REC_ORT.ORT_NR
+          </documentation>
+        </annotation>
+      </element>
+      <element name="HpEntfernung" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Entfernung zum Haltepunkt in Metern, 0 = Haltepunkt, positiv: vor Haltepunkt
+          </documentation>
+        </annotation>
+      </element>
+      <element name="TuerOffen" type="boolean" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            false: Alle Türen sind am HP geschlossen.
+            true: mindestens eine Türe ist offen.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="HaltepunktDurch" type="boolean" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            false: Fahrzeug hat am Haltepunkt gehalten.
+            true: der Haltepunkt wurde durchfahren.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Haltezeit" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Haltezeit am Haltepunkt in Sekunden.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="HaltestelleBedarf" type="boolean" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Gibt an, ob die Haltestelle eine reguläre oder
+            eine Bedarfshaltestelle ist. false= reguläre
+            Haltestelle, true = Bedarfshaltestelle
+          </documentation>
+        </annotation>
+      </element>
+      <element name="TachoStand" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Tachostand in Metern.</documentation>
+        </annotation>
+      </element>
+      <element name="Koordinate" type="husst:KoordWgs84_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="ZaehldatenListe" type="husst:Zaehldatenliste_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="Datenversion" type="int" use="required">
+      <annotation>
+        <documentation>
+          Versionsnummer des Fahrplans, auf den sich dieser Datensatz bezieht.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Geldbehaelter_Type">
+    <sequence>
+      <element name="Stueck" type="husst:Stuecke_Type" minOccurs="0" maxOccurs="unbounded"/>
+      <element name="Wert" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+    <attribute name="Typ" type="husst:GeldbehaelterTyp_Type"/>
+    <attribute name="Nr" type="int">
+      <annotation>
+        <documentation>Behälternummer</documentation>
+      </annotation>
+    </attribute>
+    <attribute name="PhysPosition" type="int" use="optional">
+      <annotation>
+        <documentation>
+          Die physikalische Position
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Geldbehaelterliste_Type">
+    <annotation>
+      <documentation>notiert die Geldwerte oder sonstige Werte (Gutscheine, Stornierungsbelege, ...) bezogen auf einen Vorgangszeitpunkt</documentation>
+    </annotation>
+    <sequence>
+      <element name="Vorgang" type="husst:GeldBehaeltervorgang_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Geldbehaelter" type="husst:Geldbehaelter_Type" minOccurs="0" maxOccurs="unbounded"/>
+      <element name="Wertbehaelter" type="husst:Wertbehaelter_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="Geraet_Type">
+    <sequence>
+      <element name="Name" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Der Name ist ein beliebiger, sprechender Name des
+            Gerätes. (z.B. Busdrucker-1234).
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Id" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eindeutige Kennung eines Bestandteils der
+            Gerätehardware (z.B. die MAC der Netzwerkhardware.) Welche Kennung
+            das ist, muss von	der Gerätesoftware entschieden werden. Das
+            Element ist optional.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+    <attribute name="Typ" type="string" use="required">
+      <annotation>
+        <documentation>
+          Der Gerätetyp entspricht den Anwendern bekannten und vorgegebenen Namen.
+          Die Liste der Gerätetypen kann beliebig erweitert werden.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="Nr" type="int" use="required">
+      <annotation>
+        <documentation>
+          Die Nummer entspricht der dem Anwender bekannten Gerätenummer.
+          Die Nummer ist nur zusammen mit der Angabe eines
+          Mandanten eindeutig.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="Mandant" type="int" use="required">
+      <annotation>
+        <documentation>
+          Die Gerätenummer ist nur zusammen mit einem
+          zugeordneten Mandant eindeutig.
+          Der Standard-Mandant ist '1'.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Gutscheinbezahlung_Type">
+    <sequence>
+      <element name="GutschId" type="husst:Tarifprodukt_Type" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>Eindeutige Kennung des Gutscheintyps</documentation>
+        </annotation>
+      </element>
+      <element name="Nr" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="KAReferenz_Type">
+    <sequence>
+      <element name="SamNummer" type="husst:INT3" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            SAM_ID.samNummer 24 Bit (Beispiel 0x654321), eine, im
+            gesamten Geltungsbereich der Kernapplikation eindeutige
+            SAM-Kartennummer
+          </documentation>
+        </annotation>
+      </element>
+      <element name="SamSequenznummer" type="husst:INT4" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            samSequenznummer 32 Bit (Beispiel 0x789ABCDE),
+            eindeutige, fortlaufende Nummer die von einer
+            SAM-Karte generiert wird.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+
+  <complexType name="Kasse_Type">
+    <sequence>
+      <element name="Betrag" type="husst:Betrag_Type" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Kassenstand in kleinster Waehrungseinheit (z.B. Cent, Rappen, etc.)
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Zahlart" type="husst:BezahlArt_Type" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Kassenliste_Type">
+    <sequence>
+      <element name="Kasse" type="husst:Kasse_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="KKOfflineBezahlung_Type">
+    <sequence>
+      <element name="Kartenherausgeber" type="husst:BezahlArt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="KartenNr" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Pruefkennung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="GueltigBis" type="gYearMonth" maxOccurs="1" minOccurs="1"/>
+      <element name="Unterschrift" type="boolean" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Komponente_Type">
+    <sequence>
+      <element name="Name" type="string" minOccurs="1" maxOccurs="1"/>
+      <element name="Version" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Variante" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="SerienNr" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="PhysPosition" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="ErstellZeitPunkt" type="dateTime" maxOccurs="1" minOccurs="0"/>
+      <element name="Hersteller" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Komponente" type="husst:Komponente_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="Klasse" type="husst:KomponentenKlasse_Type" use="required"/>
+  </complexType>
+
+  <complexType name="Komponentenliste_Type">
+    <sequence>
+      <element name="Vorgang" type="husst:KomponentenVorgang_Type"/>
+      <element name="Komponente" type="husst:Komponente_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Kontrolldaten_Type">
+    <annotation>
+      <documentation></documentation>
+    </annotation>
+    <sequence>
+      <element name="Typ" maxOccurs="1" minOccurs="1" type="string">
+        <annotation>
+          <documentation>Kontrollmeldungen beliebiger Art z. B. Chipkartenkontrolle für KA-Berechtigung, DB-Online-Ticket, BOB-Ticket, DF-Fahrschein, ...</documentation>
+        </annotation>
+      </element>
+      <element name="Kontrolldaten" type="husst:Any_Type" maxOccurs="1" minOccurs="1"/>
+      <choice>
+        <element name="KAReferenz" type="husst:KAReferenz_Type" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen KA Kontrolldaten enthalten.
+            </documentation>
+          </annotation>
+        </element>
+        <element name="Referenz" type="string" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen Transaktionsdaten als
+              Eindeutigkeitskennzeichen enthalten.
+            </documentation>
+          </annotation>
+        </element>
+      </choice>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="Kundendaten_Type">
+    <sequence>
+      <element name="Fahrgast" type="husst:Person_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Erzieher" type="husst:Person_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Lastschrift_Type">
+    <sequence>
+      <element name="BLZ-BIC" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Konto-IBAN" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="KartenfolgeNr" type="int" maxOccurs="1" minOccurs="1"/>
+      <element name="Kartenart" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>1=ec-Karte Magnetstreifen</documentation>
+        </annotation>
+      </element>
+      <element name="GueltigBis" type="gYearMonth" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>Gültigendejahr der Karte</documentation>
+        </annotation>
+      </element>
+      <element name="Unterschrift" type="boolean" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Meldung_Type">
+    <annotation>
+      <documentation>
+        Dieser Datensatz dient der Aufnahme von Textmeldungen beliebiger Art.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="Nr" type="int" minOccurs="1" maxOccurs="1"/>
+      <element name="MeldModTyp" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>Typ des meldunggenerierenden Moduls</documentation>
+        </annotation>
+      </element>
+      <element name="Komponente" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Komponentenbezeichnung</documentation>
+        </annotation>
+      </element>
+      <element name="PhysPosition" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Eine unterscheidende, physikalische Position, wenn mehrere gleiche Komponenten Meldungen emmitieren.</documentation>
+        </annotation>
+      </element>
+      <element name="Text" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Meldungstext, Entwicklertext. Dieser Text wird in
+            der Regel vor der Anzeige ersetzt.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Attribut" type="string" maxOccurs="unbounded" minOccurs="0">
+        <annotation>
+          <documentation>
+            Kommagetrennte Attribute die für eine
+            Meldungstextgenerierung benötigt werden:
+
+            Format('User "%s" was sleeping between %s and
+            %s',[Attribute])
+
+            So dass auch bei sprachvarianten Anzeigen
+            dynamische Inhalte ausgegeben werden können.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+    <attribute name="Klasse" type="husst:Meldungsklasse_Type" use="required"/>
+  </complexType>
+
+  <complexType name="Mitnahme_Type">
+    <sequence>
+      <element name="Fahrgasttyp" type="husst:KundenTyp_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Anzahl" type="int" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Ortspunkt_Type">
+    <sequence>
+      <element name="ID_Ortspunkt" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="ReferenzExtern" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Person_Type">
+    <sequence>
+      <element name="Vorname" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Nachname" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Namenszuatz" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="StrasseHausNr" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Postleitzahl" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Laenderkennzeichen" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Wohnort" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Staat" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Geschlecht" maxOccurs="1" minOccurs="0">
+        <simpleType>
+          <restriction base="string">
+            <enumeration value="weiblich"/>
+            <enumeration value="maennlich"/>
+          </restriction>
+        </simpleType>
+      </element>
+      <element name="TelefonNr" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Geburtsdatum" type="dateTime" maxOccurs="1" minOccurs="0"/>
+      <element name="Staatsangehoerigkeit" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Legitimtation" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Beschreibung der legitimation, Ausweis, EC-Karte, etc.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="LegitimationNr" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Ausweisnummer</documentation>
+        </annotation>
+      </element>
+      <element name="LegitimationsDatum" type="dateTime" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Ausstellungsdateum der Legitimation
+          </documentation>
+        </annotation>
+      </element>
+      <element name="LegimitationsLand" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Ausstellungsland der Legitimation
+          </documentation>
+        </annotation>
+      </element>
+      <element name="LegitimationBild" type="boolean" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Auf der Legitimation war ein Lichtbild, das
+            Lichtbild wurde dem EBE-Fall zugeordnet
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Polizei_Type">
+    <sequence>
+      <element name="Dienstnummer" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Vorname" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Nachname" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Dienststelle" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Preis_Type">
+    <annotation>
+      <documentation>
+        Wenn keine Preisspalte angegeben ist, wird von der
+        Standardspalte "1" ausgegangen. Ansonsten muss die Nummer der
+        zugehörigen Preisspalte der Datenversorgung angegeben.
+        Die Kennung kann optional die Kennung der Preisspalte enthalten.
+      </documentation>
+    </annotation>
+    <choice>
+      <element name="Betrag" type="husst:Betrag_Type" minOccurs="1" maxOccurs="1"/>
+      <element name="ID_Mwst" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+      <element name="MwstSatz" maxOccurs="1" minOccurs="1" type="husst:FLOAT1">
+        <annotation>
+          <documentation>
+            Wert zwischen 0 und 100
+          </documentation>
+        </annotation>
+      </element>
+    </choice>
+    <attribute name="Verrechnung" type="husst:Preisverrechnung_Type" use="required"/>
+  </complexType>
+
+  <complexType name="ProdFahrschein_Type">
+    <annotation>
+      <documentation>
+        Via = Eine Liste von Tarifpunkten
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="ZeitVon" type="dateTime" maxOccurs="1" minOccurs="1"/>
+      <element name="ZeitBis" type="dateTime" maxOccurs="1" minOccurs="0"/>
+      <element name="Von" type="husst:Transaktionsort_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Nach" type="husst:Transaktionsort_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Via" type="husst:Transaktionsort_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="ID_Relation" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Bezug auf die ID_Relation der Versorgungsdaten -
+            die Datenversion ist identisch mit der in dem
+            Tarifprodukt hinterlegten Datenversion
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Komfortklasse" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Rabattklasse" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Mitnahme" type="husst:Mitnahme_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Teilrelation" type="husst:Teilrelation_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Produkt_Type">
+    <annotation>
+      <documentation>
+        Bei der Anwendung von Teilrelationen zur Aufteilung
+        von Fremd- und Eigenleistungen wird wie folgt vorgegangen:
+        Das
+        verkaufte Produkt wird als Hauptprodukt mit der Id und ExtId
+        'anonym' eingetragen. Es gibt einen gemeinsamen Preis, einen
+        gemeinsamen Beleg, un N Teilprodukte.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="Anzahl" type="int" maxOccurs="1" minOccurs="1"/>
+      <element name="Tarifprodukt" type="husst:Tarifprodukt_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Preis" type="husst:Preis_Type" maxOccurs="unbounded" minOccurs="0">
+        <annotation>
+          <documentation>
+            Preisinformation zum Produkt, kannauch leer sein
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Fahrschein" type="husst:ProdFahrschein_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Teilprodukt" type="husst:Produkt_Type" maxOccurs="unbounded" minOccurs="0">
+        <annotation>
+          <documentation>
+            Unterprodukte, die mitverkauftwurden
+            (Teilstrecken,City-Cards,...)
+          </documentation>
+        </annotation>
+      </element>
+      <element name="AnzahlTeile" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Hier werden bei Mehrfahrtenkarten die Anzahl der
+            einzelnen Abschnitte bzw. Anteile notiert. Wenn
+            nicht angegeben ist, ist die Anzahl entweder
+            unbekannt oder als Vorgabe 1.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="RestTeile" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Hier können, je nach Kontext 1.) die Anzahl der derzeitig auf der elektronischen Mehrfahrtenkarte befindlichen "Streifen" oder 2.) die Anzahl der derzeit auf der elektronischen Debitkarte befindlichen Wertanteile notiert werden. Die Betrachtung stellt den Zustand VOR der Aktion dar.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+
+  <complexType name="Pruefabschluss_Type">
+    <sequence>
+      <element name="Ausstieg" type="husst:Transaktionsort_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Ausstiegshaltestelle</documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+    <attribute name="PruefNr" type="int" use="required">
+      <annotation>
+        <documentation></documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Pruefbeginn_Type">
+    <sequence>
+      <element name="Kleidung" type="husst:Pruefkleidung_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Die vom Prüfer getragene Kleidung
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Pruefart" type="husst:Pruefart_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Die Art der Prüfung</documentation>
+        </annotation>
+      </element>
+      <element name="Pruefer" type="string" minOccurs="0" maxOccurs="unbounded">
+        <annotation>
+          <documentation>
+            Beteiligte Prüfer (Nummer)
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Linie" type="int" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Liniennummer</documentation>
+        </annotation>
+      </element>
+      <element name="Verkehrsmittel" type="husst:TransportserviceArt_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Verkehrsmittel</documentation>
+        </annotation>
+      </element>
+      <element name="Einstieg" type="husst:Transaktionsort_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Einstiegshaltestelle</documentation>
+        </annotation>
+      </element>
+      <element name="Richtung" type="husst:Transaktionsort_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Eine Richtungsangabe</documentation>
+        </annotation>
+      </element>
+      <element name="AnzahlFahrgaeste" type="int" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Eine Abschätzung der Anzahl der Fahrgäste bei Einstieg
+          </documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+    <attribute name="PruefNr" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="Rechnungsstellung_Type">
+    <annotation>
+      <documentation>Dieses Element trägt nähere Angaben zum nachfolgenden Rechnungsstellungs- oder verfolgungsprozess.</documentation>
+    </annotation>
+    <sequence>
+      <element name="RechnungsRef" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            In der Regel eine Rechnungsnummer oder eine generierte Referenz auf eine zu erstellende Rechnung.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="KundenRef" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eine Referenz auf den Kunden zur Rechnungsstellung, in der Regel eine Kundennummer
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Vorgangszeitpunkt" type="dateTime" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Der zum Verkaufszeitpunkt zugehörige Zeitstempel.</documentation>
+        </annotation>
+      </element>
+      <element name="VorgangsRef" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Ein optionaler Bezug auf den dazugehörigen Verkaufsvorgang.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+
+  <complexType name="Restgeldbeleg_Type">
+    <sequence>
+      <element name="Ausgabevertriebsstelle" type="husst:Vertriebsstelle_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Kennung" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Eine eindeutige Kennung zur Identifikation des Restgeldbelegs.</documentation>
+        </annotation>
+      </element>
+      <element name="Beleg" type="husst:Beleg_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Ausstelldatum" type="dateTime" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Schicht_Type">
+    <sequence>
+      <element name="Datensatz" type="husst:Datensatz_Type" maxOccurs="unbounded" minOccurs="0">
+        <annotation>
+          <documentation>
+            Jede Schicht enthält 2 bis n Datensätze. Für
+            eine
+            ordentliche Schicht sollten mindestens die
+            Datensätze Schichtbeginn
+            und Schichtabschluss
+            enthalten sein.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+    <attribute name="SchichtUID" type="string" use="required">
+      <annotation>
+        <documentation>
+          Diese UID ist eine eindeutiger Wert, der (mit
+          höchster Wahrscheinlichkeit) nur einmalig für alle
+          Geräte zu allen Zeitpunkten an allen Orten existiert.
+          Alle Daten einer Schicht eines Gerätes werden mit
+          dieser ID gekennzeichnet. Die Generierungsvorschrift ist
+          beliebig, solange die obigen Bedingungen eingehalten werden.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="Projekt" type="string" use="optional">
+      <annotation>
+        <documentation>
+          Dies ist eine vom Projektierer vorgegebene
+          Projektkennzeichnung, z.B. "MENT"
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Schichtabschluss_Type">
+    <annotation>
+      <documentation>
+        Der Datensatz zum Schichtabschluss. Dieser Datensatz
+        muss paarweise mit Schichtbeginn vorkommen.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="Ausloeser" type="husst:Ausloeser_Type" minOccurs="1" maxOccurs="1"/>
+      <element name="Beleg" type="husst:Beleg_Type" minOccurs="0" maxOccurs="unbounded"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Schichtbeginn_Type">
+    <annotation>
+      <documentation>
+        Der Datensatz zum Schichtbeginn. Dieser Datensatz muss
+        paarweise mit Schichtabschluss vorkommen.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="SchichtNr" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Diese Schichtnummer enstpricht der den Anwendern
+            bekannte Schichtnummer. In der Regel wird nach
+            dieser Nummer ausgewertet und die Nummer wird
+            auf Belege aufgedruckt. Die Schichtnummer ist
+            mindestens für jede Schicht-UUID eindeutig. Die
+            Schichtnummer sollte inkrementierend aufsteigen
+            und nie '0' sein.
+
+            Achtung: Schichtnummer vs. Dienstnummer:
+            Innerhalb einer Schicht können mehrere Dienste
+            auch gleichzeitig ablaufen. Kein Dienst
+            überlappt zeitlich eine Schichtgrenze. Dienste
+            sind in der Regel Personen-(Konten) oder
+            Geräte-(Konten) zugeordnet. Schichten sind nur
+            ein Behälter für Dienste.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Geraet" type="husst:Geraet_Type" minOccurs="1" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Dieser Datensatz kennzeichnet das technische
+            Gerät, das die Datensätze dieser Schicht
+            erzeugt.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Betriebsart" type="husst:Betriebsart_Type" minOccurs="1" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Dieses Feld unterscheidet die Datensätze dieser
+            Schicht in Echt- und sonstigen Betrieb.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Standort" type="husst:Standort_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Dieses Feld bezeichnet den Standort zum
+            Schichtbeginn.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Schichtenliste_Type">
+    <sequence>
+      <element name="Version" type="husst:VersionStruktur_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Schicht" type="husst:Schicht_Type" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Schichtsummen_Type">
+    <choice>
+      <element name="Kassenliste" type="husst:Kassenliste_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="BelegKassenliste" type="husst:Belegkassenliste_Type" maxOccurs="1" minOccurs="0"/>
+    </choice>
+  </complexType>
+
+  <complexType name="Standort_Type">
+    <annotation>
+      <documentation></documentation>
+    </annotation>
+    <sequence>
+      <element name="Typ" type="husst:OrtsTyp_Type" minOccurs="1" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Mit dem Typ wird die Ausprägung des jeweilgen
+            Standorts unterschieden.
+            Die Standorte eines Typs und eines
+            Mandanten sind fortlaufend
+            durchnumeriert.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Name" type="string" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Der Name ist ein beliebiger, sprechender Name des
+            Standorts.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+    <attribute name="Nr" type="int">
+      <annotation>
+        <documentation>
+          Nummer des Nutzungsortes des Gerätes zu dem notierten Zeitpunkt.
+          Die Nummer ist dem jeweiligen Anwender bekannt.
+          Das kann eine Fahrzeugnummer sein, oder ein Kiosknummer,
+          eine Haltestellennummer oder eine Bahnhofsnummer abhängig von den
+          Projektvorgaben und definiert vom jeweiligen Mandanten sein.
+          Die Nummer ist nur zusammen mit der Angabe eines Mandanten eindeutig.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="Mandant" type="int" use="optional">
+      <annotation>
+        <documentation>
+          Die Standortnummer ist nur zusammen mit einem
+          zugeordneten Mandant eindeutig.
+          Der Standard-Mandant ist '1'.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Stuecke_Type">
+    <sequence>
+      <element name="Anzahl" type="int" maxOccurs="1" minOccurs="1"/>
+      <element name="StueckWert" type="husst:Betrag_Type" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Tarifprodukt_Type">
+    <sequence>
+      <element name="ID_Tarifgebiet" type="husst:INT4" maxOccurs="1" minOccurs="1"/>
+      <element name="ID_Sorte" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+      <element name="ReferenzExternSorte" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Preisstufe" type="husst:INT4" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Die Preisstufe ist nur zusammen mit dem Tarifgebiet gültig.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="ReferenzExternPreisstufe" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Preis" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+      <element name="ReferenzExternPreis" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Preisspalte" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+    <attribute name="DatenversionInhalt" type="string" use="required">
+      <annotation>
+        <documentation>Der Inhalt von "DatenversionInhalt" der Tabelle VersionInhalt der Versorgung</documentation>
+      </annotation>
+    </attribute>
+    <attribute name="DatenversionZeitraum" type="string" use="required">
+      <annotation>
+        <documentation>Als DatenversionZeitraum wird das Feld "DatenversionZeitraum" des zum Verkaufszeitpunkt gültigen Zeitraum-Eintrages mit der höchsten SubZeitraumNr geliefert.</documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Tarifpunkt_Type">
+    <sequence>
+      <element name="ID_Tarifpunkt" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Tarifgebiet" type="int" maxOccurs="1" minOccurs="1"/>
+      <element name="ReferenzExtern" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Teilrelation_Type">
+    <sequence>
+      <element name="SortOrder" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Die Sortierungsreihenfolge wird benötigt, um die
+            Richtung der Durchfahrt zu erhalten.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="ID_Preisstufe" type="husst:INT4" maxOccurs="1" minOccurs="1"/>
+      <element name="ReferenzExternPreisstufe" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Tarifgebiet" type="husst:INT4" maxOccurs="1" minOccurs="1"/>
+
+      <element name="Start" type="husst:Tarifpunkt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Ziel" type="husst:Tarifpunkt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="ReferenzExternRelation" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Preisquelle" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DatenversionInhalt" type="string" use="required">
+      <annotation>
+        <documentation>Der Inhalt von "DatenversionInhalt" der Tabelle VersionInhalt der Versorgung</documentation>
+      </annotation>
+    </attribute>
+    <attribute name="DatenversionZeitraum" type="string" use="required">
+      <annotation>
+        <documentation>Als DatenversionZeitraum wird das Feld "DatenversionZeitraum" des zum Verkaufszeitpunkt gültigen Zeitraum-Eintrages mit der höchsten SubZeitraumNr geliefert.</documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Transaktion_Type">
+    <sequence>
+      <element name="Produkt" type="husst:Produkt_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="KundenNr" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="BezugsNr" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Die BezugsNr enthält bei EBE-Vorgängen die EBE-Kontonummer, bei Gutschein-Vorgängen die Gutscheinnummer, bei Bezahlung bzw. Einlösung von Anteilen vorausbezahlter Anteile auf Karten die Kartennummer.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Vorgangszeitpunkt" type="dateTime" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Vorgangsnummer und Vorgangszeitpunkt
+            identifizieren einzeln oder gemeinsam einen
+            Vorgang. Im Speziellen werden diese beiden Werte
+            bei der Erstattung eines Gutscheins genutzt,
+            dann entspricht der Vorgangszeitpunkt dem
+            Zeitpunkt der Ausgabe des eingelösten
+            Gutscheins.
+          </documentation>
+        </annotation>
+      </element>
+      <choice>
+        <element name="KAReferenz" type="husst:KAReferenz_Type" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen KA Kontrolldaten enthalten.
+            </documentation>
+          </annotation>
+        </element>
+        <element name="Referenz" type="string" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen Transaktionsdaten als
+              Eindeutigkeitskennzeichen enthalten.
+            </documentation>
+          </annotation>
+        </element>
+      </choice>
+    </sequence>
+    <attribute name="Typ" type="husst:TransaktionTyp_Type" use="required"/>
+    <attribute name="Storno" type="boolean" use="optional" default="false"/>
+  </complexType>
+
+  <complexType name="Transaktionsdaten_Type">
+    <sequence>
+      <element name="Transaktionsart" maxOccurs="1" minOccurs="1" type="husst:Transaktionsart_Type"/>
+      <element name="Transaktionsdaten" type="husst:Any_Type" maxOccurs="1" minOccurs="1"/>
+      <choice>
+        <element name="KAReferenz" type="husst:KAReferenz_Type" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen KA Kontrolldaten enthalten.
+            </documentation>
+          </annotation>
+        </element>
+        <element name="Referenz" type="string" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen Kontrolldaten als
+              Eindeutigkeitskennzeichen enthalten.
+            </documentation>
+          </annotation>
+        </element>
+      </choice>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Transaktionsliste_Type">
+    <sequence>
+      <element name="Transaktion" type="husst:Transaktion_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Transaktionsort_Type">
+    <sequence>
+      <element name="Ortspunkt" type="husst:Ortspunkt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Tarifpunkt" type="husst:Tarifpunkt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Relcode" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Dieser Inhalt referenziert den Relationscode des Tarifs</documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DatenversionInhalt" type="string" use="required">
+      <annotation>
+        <documentation>Der Inhalt von "DatenversionInhalt" der Tabelle VersionInhalt der Versorgung</documentation>
+      </annotation>
+    </attribute>
+    <attribute name="DatenversionZeitraum" type="string" use="required">
+      <annotation>
+        <documentation>Als DatenversionZeitraum wird das Feld "DatenversionZeitraum" des zum Verkaufszeitpunkt gültigen Zeitraum-Eintrages mit der höchsten SubZeitraumNr geliefert.</documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Ueberweisung_Type">
+    <sequence>
+      <element name="BLZ-BIC" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Konto-IBAN" type="string" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Verfolgung_Type">
+    <sequence>
+      <element name="Typ" type="husst:VerfolgungsTyp_Type" maxOccurs="unbounded" minOccurs="1"/>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="VersionStruktur_Type">
+		<annotation>
+			<documentation>
+        Hier müssen Hinweise zur Version des Schemas angegeben werden.
+      </documentation>
+		</annotation>
+		<sequence>
+			<element name="VersionMajor" type="int" maxOccurs="1" minOccurs="1" default="3">
+				<annotation>
+					<documentation>
+            Diese Versionsnummer muss sich immer bei Inkompatibilitäten zur Vorgängerversion ändern.
+          </documentation>
+				</annotation>
+			</element>
+			<element name="VersionMinor" type="int" maxOccurs="1" minOccurs="1" default="0">
+				<annotation>
+					<documentation>
+            Diese Versionsnummer zählt kompatible Anpassungen.
+					</documentation>
+				</annotation>
+			</element>
+			<element name="Aenderungsdatum" type="date" maxOccurs="1" minOccurs="1" default="2019-05-10"/>
+			<element name="Aenderungsautor" type="string" maxOccurs="1" minOccurs="1" default="Klaus Hitschler (krauth technology)"/>
+		</sequence>
+	</complexType>
+
+
+  <complexType name="Vertriebsstelle_Type">
+    <sequence>
+      <element name="Typ" maxOccurs="1" minOccurs="1" type="husst:OrtsTyp_Type">
+        <annotation>
+          <documentation>
+            Der Typ qualifiziert die beiden Elemente
+            'Mandant' und 'Nr'.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Mandant" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Der Mandant qualifiziert eindeutig die
+            Zugehörigkeit der 'Nr'.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Nr" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Hier wird, je nach ktVerkaufsstellenType, die
+            Personalnummer, die Verkaufsstellennummer, die
+            Gerätenummer etc. hinterlegt. Die Nummer ist nur
+            in Beziehung zu Mandant und dem Typ eindeutig.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+  
+  <complexType name="Warenkorb_Type">
 		<sequence>
 			<element name="Transaktionsort" type="husst:Transaktionsort_Type" maxOccurs="1" minOccurs="1"/>
 			<element name="Transaktionliste" type="husst:Transaktionsliste_Type" maxOccurs="1" minOccurs="1"/>
 			<element name="Zahlungsliste" type="husst:Zahlungsliste_Type" maxOccurs="1" minOccurs="0"/>
 			<element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
-
 		</sequence>
 		<attribute name="DienstNr" type="int" use="required"/>
 	</complexType>
 
+  <complexType name="Wertbehaelter_Type">
+    <annotation>
+      <documentation>
+        Hiermit werden Wertbehälter erfasst, z.B. Safebags.
+        Die Nummer enstpricht der Nummer des Wertbehälters, die Wertanzahl
+        der Anzahl der werthaltigen Anteile, z.B. die Anzahl der Belege.
+
+        Es werden 2 Behälter unterschieden:
+        1. Behälter mit Bargeld -> dann muss der Betrag ausgefüllt sein (früher Wert),
+        2. Behälter mit werthaltigen Belegen -> dann muss die Wertanzahl ausgefüllt sein.
+        3. Eine Mischform ist auch möglich.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="WertAnzahl" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="Betrag" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="Kennung" type="string" use="required"/>
+  </complexType>
+
+  <complexType name="Zaehldaten_Type">
+    <sequence>
+      <element name="Einsteiger" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+      <element name="Aussteiger" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+      <element name="Fehler" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+    <attribute name="Kennung" type="int" use="required">
+      <annotation>
+        <documentation>
+          Die spezielle Bezeichnung dieser Zähldatneinheit
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Zaehldatenliste_Type">
+    <sequence>
+      <element name="Zaehldaten" type="husst:Zaehldaten_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+  
 	<complexType name="Zahlung_Type">
 		<sequence>
 			<element name="Betrag" type="husst:Betrag_Type" maxOccurs="1" minOccurs="1"/>
@@ -50,229 +1659,177 @@
 				<element name="Restgeldbeleg" type="husst:Restgeldbeleg_Type" maxOccurs="1" minOccurs="1"/>
 				<element name="Rechnungsstellung" type="husst:Rechnungsstellung_Type" maxOccurs="1" minOccurs="1"/>
 			</choice>
-
 			<element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
 		</sequence>
 	</complexType>
 
+  <complexType name="Zahlungsliste_Type">
+    <sequence>
+      <element name="Zahlung" type="husst:Zahlung_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
 
-	<complexType name="Fahrtverlauf_Type">
+  <complexType name="ZVTBezahlung_Type">
+    <sequence>
+      <element name="Kartenherausgeber" type="husst:BezahlArt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="TerminalId" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="TransaktionsNr" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Zeitpunkt" type="dateTime" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  
+  <simpleType name="Betriebszeit_Type">
+    <annotation>
+      <documentation>
+        Betriebszeiten dürfen über 24:00 Uhr hinausgehen
+      </documentation>
+    </annotation>
+    <restriction base="string">
+      <pattern value="[0-9]{1,2}:[0-9]{1,2}" />
+    </restriction>
+  </simpleType>
+  
+  <simpleType name="blobString">
+    <restriction base="string">
+      <pattern value="[ -þ€–]*" />
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Char">
+    <restriction base="string">
+      <minLength value="1" />
+      <maxLength value="1" />
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Codierung_Type">
+    <annotation>
+      <documentation>
+        Die Codierung entspricht der DB-Codierung
+      </documentation>
+    </annotation>
+    <restriction base="string">
+      <pattern value="[1-9a-zA-Z]{2}"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="DateCompact">
+    <restriction base="date">
+      <minInclusive value="1990-01-01" />
+      <maxInclusive value="2117-12-31" />
+    </restriction>
+  </simpleType>
+
+  <simpleType name="DateTimeCompact">
+    <restriction base="dateTime">
+      <minInclusive value="1990-01-01T00:00:00Z" />
+      <maxInclusive value="2117-12-31T23:59:58Z" />
+    </restriction>
+  </simpleType>
+
+  <simpleType name="FLOAT1">
+    <annotation>
+      <documentation>
+        englische Notation beachten, z. B. 19 Euro = 19.00 Euro
+      </documentation>
+    </annotation>
+    <restriction base="decimal">
+      <minInclusive value="0" />
+      <maxInclusive value="100" />
+    </restriction>
+  </simpleType>
+
+  <simpleType name="INT1">
+    <restriction base="unsignedInt">
+      <minInclusive value="0" />
+      <maxInclusive value="255" />
+    </restriction>
+  </simpleType>
+  <simpleType name="INT2">
+    <restriction base="unsignedInt">
+      <minInclusive value="0" />
+      <maxInclusive value="65535" />
+    </restriction>
+  </simpleType>
+  <simpleType name="INT3">
+    <restriction base="unsignedInt">
+      <minInclusive value="0" />
+      <maxInclusive value="16777215" />
+    </restriction>
+  </simpleType>
+  <simpleType name="INT4">
+    <restriction base="unsignedInt">
+      <minInclusive value="0" />
+      <maxInclusive value="4294967295" />
+    </restriction>
+  </simpleType>
+  <simpleType name="INT8">
+    <restriction base="unsignedLong">
+      <minInclusive value="0" />
+      <maxInclusive value="18446744073709551615" />
+    </restriction>
+  </simpleType>
+
+  <simpleType name="KoordWgs84_Type">
+    <restriction base="float"/>
+  </simpleType>
+
+  <simpleType name="Waehrung_Type">
+    <annotation>
+      <documentation>Währungscode nach ISO 4217.</documentation>
+    </annotation>
+    <restriction base="string">
+      <pattern value="[A-Z]{3}"/>
+    </restriction>
+  </simpleType>
+  
+
+  <simpleType name="Projektspezifisch_Type">
+    <annotation>
+      <documentation>Erlaubt alle Werte, die nicht mit "husst." beginnen.</documentation>
+    </annotation>
+    <restriction base="string">
+      <pattern value="((h[^u])|hu[^s]|hus[^s]|huss[^t]|husst[^\.]|[a-gi-zA-ZöäüÖÄÜß][a-zA-ZöäüÖÄÜß0-9]*)([\-\.][a-zA-ZöäüÖÄÜß0-9]+)*"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="ProjektspezifischAnstattKa_Type">
 		<annotation>
-			<documentation>Diese Datensätze beinhalten, abweichend von anderen Datensätzen,  Information aus betrieblichen VDV452 Daten.</documentation>
-		</annotation>
-		<sequence>
-			<element name="Betrieb" type="husst:INT4" minOccurs="1" maxOccurs="1">
-				<annotation>
-					<documentation>
-						REC_FRT.BETRIEB aus VDV bei Mandantensystemen,
-						sonst 0.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="FahrzeugNr" type="husst:INT4" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						Nach VDV FAHRZEUG.FZG_NR
-					</documentation>
-				</annotation>
-			</element>
-			<element name="FahrzeugUnr" type="husst:INT4" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Nummer des Unternehmens, dem das Fahrzeug
-						gehört. FAHRZEUG.ABK_UNTERNEHMEN
-					</documentation>
-				</annotation>
-			</element>
-			<element name="FahrerNr" type="husst:INT4" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Nch VDV: PERSONAL.FAHRER_NR</documentation>
-				</annotation>
-			</element>
-			<element name="FahrerUnr" type="husst:INT4" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Nach VDV: PERSONAL.ABK_UNTERNEHMEN -> TEILNEHMER.UNTERNEHMEN
-					</documentation>
-				</annotation>
-			</element>
-			<element name="FahrtID" type="husst:INT4" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						Fahrtnummer der Fahrt laut VDV REC_FRT.FRT_ID
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Fahrt" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Optionale Kennung der Fahrt als Text.</documentation>
-				</annotation>
-			</element>
-			<element name="LinieID" type="husst:INT4" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Nach VDV: Aus der Tabelle REC_LID.LI_NR
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Linie" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Optionale Linieninformation als Text. Optional REC_LID.LIDNAME oder REC_LID.LI_KUERZEL</documentation>
-				</annotation>
-			</element>
-			<element name="Richtung" type="int" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Nach VDV: REC_LID.LI_RI_NR
-					</documentation>
-				</annotation>
-			</element>
-			<element name="FahrplanLage" type="int" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Fahrplanlage in Sekunden, negative Werte für
-						Verfrühung.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="OrtTyp" type="husst:INT4" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Nach VDV: REC_ORT.ONR_TYP_NR</documentation>
-				</annotation>
-			</element>
-			<element name="OrtNr" type="husst:INT4" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Haltepunktnummer nach VDV: REC_ORT.ORT_NR
-					</documentation>
-				</annotation>
-			</element>
-			<element name="HpEntfernung" type="int" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Entfernung zum Haltepunkt in Metern, 0 =
-						Haltepunkt, positiv: vor Haltepunkt
-					</documentation>
-				</annotation>
-			</element>
-			<element name="TuerOffen" type="boolean" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						false Alle Türen sind am HP geschlossen, true
-						mindestens eine Türe ist offen.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="HaltepunktDurch" type="boolean" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						false Fahrzeug hat am Haltepunkt gehalten, true der
-						Haltepunkt wurde durchfahren.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Haltezeit" type="husst:INT4" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Haltezeit am Haltepunkt in Sekunden.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="HaltestelleBedarf" type="boolean" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Gibt an, ob die Haltestelle eine reguläre oder
-						eine Bedarfshaltestelle ist. false= reguläre
-						Haltestelle, true = Bedarfshaltestelle
-					</documentation>
-				</annotation>
-			</element>
-			<element name="TachoStand" type="husst:INT4" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Tachostand in Metern.
-					</documentation>
-				</annotation>
-			</element>
-
-
-
-
-
-
-
-			<element name="Koordinate" type="husst:KoordWgs84_Type" maxOccurs="1" minOccurs="0"/>
-
-
-
-
-
-			<element name="ZaehldatenListe" type="husst:Zaehldatenliste_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="Datenversion" type="int" use="required">
-			<annotation>
-				<documentation>
-		Versionsnummer des Fahrplans, auf den sich dieser Datensatz bezieht. 
-				</documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-
-	<complexType name="Meldung_Type">
-		<annotation>
-			<documentation>Dieser Datensatz dient der Aufnahme von Textmeldungen beliebiger Art.
+			<documentation>
+				Definiert einen Typ, der anstatt eines Wertes aus der KA-Enumeration genutzt werden kann.
+				Die KA-Enumerationen definieren Werte zwischen 1 und 255 (INT1). Wenn Buchstaben vorkommen, ist es ein Projektspezifischer Wert.
 			</documentation>
 		</annotation>
-		<sequence>
-			<element name="Nr" type="int" minOccurs="1" maxOccurs="1"/>
-			<element name="MeldModTyp" type="string" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>Typ des meldunggenerierenden Moduls</documentation>
-				</annotation>
-			</element>
-			<element name="Komponente" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Komponentenbezeichnung</documentation>
-				</annotation>
-			</element>
-			<element name="PhysPosition" type="int" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Eine unterscheidende, physikalische Position, wenn mehrere gleiche Komponenten Meldungen emmitieren.</documentation>
-				</annotation>
-			</element>
-			<element name="Text" type="string" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>Meldungstext, Entwicklertext. Dieser Text wird in
-						der Regel vor der Anzeige ersetzt.</documentation>
-				</annotation>
-			</element>
-			<element name="Attribut" type="string" maxOccurs="unbounded" minOccurs="0">
-				<annotation>
-					<documentation>
-						Kommagetrennte Attribute die für eine
-						Meldungstextgenerierung benötigt werden:
+		<restriction base="string">
+			<pattern value="[A-Za-z][A-Za-z0-9_]*"/>
+		</restriction>
+	</simpleType>
+  
+  
+  <simpleType name="AusgabeabschnittTyp_Type">
+    <annotation>
+      <documentation>Beschreibt den Typ eines ausgegebenen Papierdokumentes näher.</documentation>
+    </annotation>
+    <union memberTypes="husst:AusgabeabschnittTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="AusgabeabschnittTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Fahrschein"/>
+      <enumeration value="husst.Rollenbeginn"/>
+      <enumeration value="husst.Rollenende"/>
+      <enumeration value="husst.Probedruck"/>
+      <enumeration value="husst.Quittung"/>
+      <enumeration value="husst.Beleg"/>
+    </restriction>
+  </simpleType>
 
-						Format('User "%s" was
-						sleeping between %s and
-						%s',[Attribute])
-
-						So dass auch bei
-						sprachvarianten Anzeigen
-						dynamische Inhalte ausgegeben werden
-						können.
-					</documentation>
-				</annotation>
-			</element>
-		</sequence>
-		<attribute name="Klasse" type="husst:Meldungsklasse_Type" use="required"/>
-	</complexType>
-
-	<simpleType name="Ausloeser_Type">
+  <simpleType name="Ausloeser_Type">
 		<annotation>
 			<documentation></documentation>
 		</annotation>
 		<union memberTypes="husst:AusloeserHUSST_Type husst:Projektspezifisch_Type"/>
 	</simpleType>
-
 	<simpleType name="AusloeserHUSST_Type">
 		<restriction base="string">
 			<enumeration value="husst.manuell"/>
@@ -280,60 +1837,646 @@
 		</restriction>
 	</simpleType>
 
-	<complexType name="Transaktion_Type">
-		<sequence>
-			<element name="Produkt" type="husst:Produkt_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="KundenNr" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="BezugsNr" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-                     Die BezugsNr enthält bei EBE-Vorgängen die EBE-Kontonummer, bei Gutschein-Vorgängen die Gutscheinnummer, bei Bezahlung bzw. Einlösung von Anteilen vorausbezahlter Anteile auf Karten die Kartennummer. 
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Vorgangszeitpunkt" type="dateTime" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Vorgangsnummer und Vorgangszeitpunkt
-						identifizieren einzeln oder gemeinsam einen
-						Vorgang. Im Speziellen werden diese beiden Werte
-						bei der Erstattung eines Gutscheins genutzt,
-						dann entspricht der Vorgangszeitpunkt dem
-						Zeitpunkt der Ausgabe des eingelösten
-						Gutscheins.
-					</documentation>
-				</annotation>
-			</element>
-			<choice>
-				<element name="KAReferenz" type="husst:KAReferenz_Type" maxOccurs="1" minOccurs="0">
-					<annotation>
-						<documentation>
-							Referenz zu einem global eindeutigen Vorgang
-							- diese Information ist auch in den
-							zugehörigen KA Kontrolldaten enthalten.
-						</documentation>
-					</annotation>
-				</element>
-				<element name="Referenz" type="string" maxOccurs="1" minOccurs="0">
-					<annotation>
-						<documentation>
-							Referenz zu einem global eindeutigen Vorgang
-							- diese Information ist auch in den
-							zugehörigen Transaktionsdaten als
-							Eindeutigkeitskennzeichen enthalten.
-						</documentation>
-					</annotation>
-				</element>
-			</choice>
-		</sequence>
-		<attribute name="Typ" type="husst:TransaktionTyp_Type" use="required"/>
-		<attribute name="Storno" type="boolean" use="optional" default="false"/>
-	</complexType>
+  <simpleType name="BelegkasseTyp_Type">
+    <annotation>
+      <documentation></documentation>
+    </annotation>
+    <union memberTypes="husst:BelegkasseTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="BelegkasseTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Restgeldquittung"/>
+      <enumeration value="husst.Stornierung"/>
+      <enumeration value="husst.Gutschein"/>
+      <enumeration value="husst.Ruecknahme"/>
+      <enumeration value="husst.Chipkarte"/>
+      <enumeration value="husst.Flugcoupon"/>
+      <enumeration value="husst.Anfahrtscoupon"/>
+    </restriction>
+  </simpleType>
 
+  <simpleType name="BelegTyp_Type">
+    <annotation>
+      <documentation></documentation>
+    </annotation>
+    <union memberTypes="husst:BelegTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="BelegTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Papier"/>
+      <enumeration value="husst.ECard"/>
+      <enumeration value="husst.KACard"/>
+      <enumeration value="husst.BOBCard"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Betriebsart_Type">
+    <union memberTypes="husst:BetriebsartHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="BetriebsartHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Echtbetrieb"/>
+      <enumeration value="husst.Testbetrieb"/>
+      <enumeration value="husst.Schulungsbetrieb"/>
+    </restriction>
+  </simpleType>
+
+  <complexType name="BezahlArt_Type">
+    <simpleContent>
+      <extension base="husst:BezahlArtSimple_Type">
+        <attribute name="Bezeichnung" type="string" use="optional">
+          <annotation>
+            <documentation>
+              Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
+            </documentation>
+          </annotation>
+        </attribute>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <simpleType name="BezahlArtSimple_Type">
+    <union memberTypes="husst:BezahlArtKa_Type husst:ProjektspezifischAnstattKa_Type"/>
+  </simpleType>
+  <simpleType name="BezahlArtKa_Type">
+    <annotation>
+      <documentation>
+        Die BezahlArt kommt aus der VDV-KA.
+        Die KA-Werte kommen aus dem EN1545: PaymentMeansCode
+      </documentation>
+    </annotation>
+    <restriction base="husst:INT1">
+      <enumeration value="0">
+        <annotation>
+          <documentation>Keine Angabe</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="1">
+        <annotation>
+          <documentation>Bar</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="3">
+        <annotation>
+          <documentation>Kreditkarte</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="5">
+        <annotation>
+          <documentation>POB/PEB</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="6">
+        <annotation>
+          <documentation>EC-Karte/Lastschrift</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="7">
+        <annotation>
+          <documentation>Rechnung</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="8">
+        <annotation>
+          <documentation>Werteinheiten</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="14">
+        <annotation>
+          <documentation>Gutschein/Voucher</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="17">
+        <annotation>
+          <documentation>ec-Cash</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="24">
+        <annotation>
+          <documentation>Geldkarte</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="25">
+        <annotation>
+          <documentation>Mastercard</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="26">
+        <annotation>
+          <documentation>Visacard</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="27">
+        <annotation>
+          <documentation>HandyTicket Konto</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="28">
+        <annotation>
+          <documentation>Mobilfunkrechnung</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="100">
+        <annotation>
+          <documentation>Amazon Pay</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="101">
+        <annotation>
+          <documentation>Amex</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="102">
+        <annotation>
+          <documentation>Android Pay</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="103">
+        <annotation>
+          <documentation>Apple-Pay</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="104">
+        <annotation>
+          <documentation>(Sonstige) Appbasierte Zahlverfahren</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="105">
+        <annotation>
+          <documentation>Girocard kontaktlos</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="106">
+        <annotation>
+          <documentation>Girogo (GeldKarte kontaktlos)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="107">
+        <annotation>
+          <documentation>Giropay</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="108">
+        <annotation>
+          <documentation>Maestro</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="109">
+        <annotation>
+          <documentation>Mastercard paypass (kontaktlos)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="110">
+        <annotation>
+          <documentation>Paydirekt</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="111">
+        <annotation>
+          <documentation>PayPal</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="112">
+        <annotation>
+          <documentation>PrintTicket-Konto</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="113">
+        <annotation>
+          <documentation>Sofortüberweisung</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="114">
+        <annotation>
+          <documentation>V-Pay</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="115">
+        <annotation>
+          <documentation>VISA paywave (kontaktlos)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="116">
+        <annotation>
+          <documentation>(Sonstige) Web-basierte Zahlverfahren</documentation>
+        </annotation>
+      </enumeration>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="GeldbehaelterTyp_Type">
+    <union memberTypes="husst:GeldbehaelterTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="GeldbehaelterTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Personenkasse"/>
+      <enumeration value="husst.Muenzendkasse"/>
+      <enumeration value="husst.Banknotenendkasse"/>
+      <enumeration value="husst.Geldwechsler"/>
+      <enumeration value="husst.Geldspeicher"/>
+      <enumeration value="husst.Zwischenkasse"/>
+      <enumeration value="husst.Wertbehaelter"/>
+      <enumeration value="husst.Handkasse"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="GeldBehaeltervorgang_Type">
+    <annotation>
+      <documentation>
+        Übergabemeldung dient zur Registrierung von Safebag-Nummern.
+      </documentation>
+    </annotation>
+    <union memberTypes="husst:GeldBehaeltervorgangHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="GeldBehaeltervorgangHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Anfangsbestand"/>
+      <enumeration value="husst.Endbestand"/>
+      <enumeration value="husst.Behaelterzufuehrung"/>
+      <enumeration value="husst.Behaelterentnahme"/>
+      <enumeration value="husst.Bestandsaufnahme"/>
+      <enumeration value="husst.Befuellung"/>
+      <enumeration value="husst.Entnahme"/>
+      <enumeration value="husst.Uebergabemeldung"/>
+      <enumeration value="husst.Entnahmemeldung"/>
+      <enumeration value="husst.Geldabwurf"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="KasseTyp_Type">
+    <annotation>
+      <documentation></documentation>
+    </annotation>
+    <union memberTypes="husst:KasseTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="KasseTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.bar"/>
+      <enumeration value="husst.unbar"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="KomponentenKlasse_Type">
+    <union memberTypes="husst:KomponentenKlasseHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="KomponentenKlasseHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Software"/>
+      <enumeration value="husst.Hardware"/>
+      <enumeration value="husst.Daten"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="KomponentenVorgang_Type">
+    <union memberTypes="husst:KomponentenVorgangHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="KomponentenVorgangHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Entnahme"/>
+      <enumeration value="husst.Zufuehrung"/>
+      <enumeration value="husst.Bestandsaufnahme"/>
+      <enumeration value="husst.Update"/>
+    </restriction>
+  </simpleType>
+
+  <complexType name="KundenTyp_Type">
+    <simpleContent>
+      <extension base="husst:KundenTypSimple_Type">
+        <attribute name="Bezeichnung" type="string" use="optional">
+          <annotation>
+            <documentation>
+              Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
+            </documentation>
+          </annotation>
+        </attribute>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <simpleType name="KundenTypSimple_Type">
+    <union memberTypes="husst:KundenTypKa_Type husst:ProjektspezifischAnstattKa_Type"/>
+  </simpleType>
+  <simpleType name="KundenTypKa_Type">
+    <annotation>
+      <documentation>
+        Der Kundentyp kommt aus der VDV-KA.
+        Die KA-Werte kommen aus dem EN1545: ProfileCodeIOP
+      </documentation>
+    </annotation>
+    <restriction base="husst:INT1">
+      <enumeration value="0">
+        <annotation>
+          <documentation>nicht spezifiziert/unbestimmt</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="1">
+        <annotation>
+          <documentation>Erwachsener</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="2">
+        <annotation>
+          <documentation>Kind</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="3">
+        <annotation>
+          <documentation>Student</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="5">
+        <annotation>
+          <documentation>Behinderter</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="6">
+        <annotation>
+          <documentation>Sehbehinderter</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="7">
+        <annotation>
+          <documentation>Hoergeschaedigter</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="8">
+        <annotation>
+          <documentation>Arbeitsloser/Sozialhilfeempfaenger</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="9">
+        <annotation>
+          <documentation>Personal</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="10">
+        <annotation>
+          <documentation>Militaeranhehoeriger</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="19">
+        <annotation>
+          <documentation>Schueler</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="20">
+        <annotation>
+          <documentation>Azubi</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="25">
+        <annotation>
+          <documentation>Senior</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="64">
+        <annotation>
+          <documentation>ermäßigt</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="65">
+        <annotation>
+          <documentation>Fahrrad</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="66">
+        <annotation>
+          <documentation>Hund</documentation>
+        </annotation>
+      </enumeration>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Meldungsklasse_Type">
+    <union memberTypes="husst:MeldungsklasseHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="MeldungsklasseHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Debug"/>
+      <enumeration value="husst.Info"/>
+      <enumeration value="husst.Warnung"/>
+      <enumeration value="husst.Fehler"/>
+      <enumeration value="husst.SchwererFehler"/>
+    </restriction>
+  </simpleType>
+
+  <complexType name="OrtsTyp_Type">
+    <simpleContent>
+      <extension base="husst:OrtsTypSimple_Type">
+        <attribute name="Bezeichnung" type="string" use="optional">
+          <annotation>
+            <documentation>
+              Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
+            </documentation>
+          </annotation>
+        </attribute>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <simpleType name="OrtsTypSimple_Type">
+    <union memberTypes="husst:OrtsTypKa_Type husst:ProjektspezifischAnstattKa_Type"/>
+  </simpleType>
+  <simpleType name="OrtsTypKa_Type">
+    <annotation>
+      <documentation>
+        Der OrtsTyp kommt aus der VDV-KA.
+        Die KA-Werte kommen aus dem EN1545: LocationTypeCode
+      </documentation>
+    </annotation>
+    <restriction base="husst:INT1">
+      <enumeration value="0">
+        <annotation>
+          <documentation>Bushaltestelle</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="1">
+        <annotation>
+          <documentation>U-Bahn- (Metro-)Station</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="2">
+        <annotation>
+          <documentation>Bahnhof (Eisenbahn)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="3">
+        <annotation>
+          <documentation>Strassenbahn- (TRAM-) Haltestelle</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="11">
+        <annotation>
+          <documentation>Verkaufsstelle</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="16">
+        <annotation>
+          <documentation>Gebiet(auch fuer Zone)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="17">
+        <annotation>
+          <documentation>Korridor</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="200">
+        <annotation>
+          <documentation>
+            Haltestelle allgemein
+            fuer Haltestellen im Fahrplansinne,
+            unabhaengig vom Verkehrsmittel
+          </documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="201">
+        <annotation>
+          <documentation>Massenpersonalisierer</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="202">
+        <annotation>
+          <documentation>areaList_ID</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="203">
+        <annotation>
+          <documentation>im Fahrzeug/Zug</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="204">
+        <annotation>
+          <documentation>TouchPoint</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="205">
+        <annotation>
+          <documentation>im Fahrzeug der Linie</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="206">
+        <annotation>
+          <documentation>im Fahrzeug der Zugnummer</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="207">
+        <annotation>
+          <documentation>Teilzone</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="208">
+        <annotation>
+          <documentation>neutrale Zone</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="209">
+        <annotation>
+          <documentation>Wabe</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="210">
+        <annotation>
+          <documentation>Grosswabe</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="211">
+        <annotation>
+          <documentation>Tarifpunkt</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="212">
+        <annotation>
+          <documentation>Backoffice</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="213">
+        <annotation>
+          <documentation>im Fahrzeug an Haltestelle</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="214">
+        <annotation>
+          <documentation>Ereignisort (event location)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="215">
+        <annotation>
+          <documentation>Ticketserver</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="251">
+        <annotation>
+          <documentation>Ortsteil</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="252">
+        <annotation>
+          <documentation>Gemeinde</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="253">
+        <annotation>
+          <documentation>Kreis</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="254">
+        <annotation>
+          <documentation>Land</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="255">
+        <annotation>
+          <documentation>keine Angabe</documentation>
+        </annotation>
+      </enumeration>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Preisverrechnung_Type">
+    <union memberTypes="husst:PreisverrechnungHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="PreisverrechnungHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Basispreis"/>
+      <enumeration value="husst.Abschlag"/>
+      <enumeration value="husst.Zuschlag"/>
+      <enumeration value="husst.Information"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Pruefart_Type">
+    <union memberTypes="husst:PruefartHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="PruefartHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Standardpruefung"/>
+      <enumeration value="husst.Abgangskontrolle"/>
+      <enumeration value="husst.Sonstiges"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Pruefkleidung_Type">
+    <union memberTypes="husst:PruefkleidungHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="PruefkleidungHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Zivilkleidung"/>
+      <enumeration value="husst.Dienstkleidung"/>
+      <enumeration value="husst.Sonstiges"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Transaktionsart_Type">
+    <union memberTypes="husst:TransaktionsartHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="TransaktionsartHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.KA"/>
+      <enumeration value="husst.Geldkarte"/>
+      <enumeration value="husst.BOB"/>
+    </restriction>
+  </simpleType>
+  
 	<simpleType name="TransaktionTyp_Type">
 		<union memberTypes="husst:TransaktionTypHUSST_Type husst:Projektspezifisch_Type"/>
 	</simpleType>
-
 	<simpleType name="TransaktionTypHUSST_Type">
 		<annotation>
 			<documentation>Sonderfälle:
@@ -365,2432 +2508,162 @@
 		</restriction>
 	</simpleType>
 
-	<complexType name="Produkt_Type">
-		<annotation>
-			<documentation>Bei der Anwendung von Teilrelationen zur Aufteilung
-				von Fremd- und Eigenleistungen wird wie folgt vorgegangen:
-				Das
-				verkaufte Produkt wird als Hauptprodukt mit der Id und ExtId
-				'anonym' eingetragen. Es gibt einen gemeinsamen Preis, einen
-				gemeinsamen Beleg, un N Teilprodukte.
-			</documentation>
-		</annotation>
-		<sequence>
-			<element name="Anzahl" type="int" maxOccurs="1" minOccurs="1"/>
-			<element name="Tarifprodukt" type="husst:Tarifprodukt_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Preis" type="husst:Preis_Type" maxOccurs="unbounded" minOccurs="0">
-				<annotation>
-					<documentation>
-						Preisinformation zum Produkt, kannauch leer sein
-					</documentation>
-				</annotation>
-			</element>
-
-			<element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
-			<element name="Fahrschein" type="husst:ProdFahrschein_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="Teilprodukt" type="husst:Produkt_Type" maxOccurs="unbounded" minOccurs="0">
-				<annotation>
-					<documentation>
-						Unterprodukte, die mitverkauftwurden
-						(Teilstrecken,City-Cards,...)
-					</documentation>
-				</annotation>
-			</element>
-			<element name="AnzahlTeile" type="int" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Hier werden bei Mehrfahrtenkarten die Anzahl der
-						einzelnen Abschnitte bzw. Anteile notiert. Wenn
-						nicht angegeben ist, ist die Anzahl entweder
-						unbekannt oder als Vorgabe 1.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="RestTeile" type="int" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Hier können, je nach Kontext 1.) die Anzahl der derzeitig auf der elektronischen Mehrfahrtenkarte befindlichen "Streifen" oder 2.) die Anzahl der derzeit auf der elektronischen Debitkarte befindlichen Wertanteile notiert werden. Die Betrachtung stellt den Zustand VOR der Aktion dar.</documentation>
-				</annotation>
-			</element>
-		</sequence>
-
-	</complexType>
-
-	<complexType name="ProdFahrschein_Type">
-		<annotation>
-			<documentation>Via = Eine Liste von Tarifpunkten
-			</documentation>
-		</annotation>
-		<sequence>
-
-			<element name="ZeitVon" type="dateTime" maxOccurs="1" minOccurs="1"/>
-			<element name="ZeitBis" type="dateTime" maxOccurs="1" minOccurs="0"/>
-			<element name="Von" type="husst:Transaktionsort_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="Nach" type="husst:Transaktionsort_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="Via" type="husst:Transaktionsort_Type" maxOccurs="unbounded" minOccurs="0"/>
-
-
-			<element name="ID_Relation" type="husst:INT4" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Bezug auf die ID_Relation der Versorgungsdaten -
-						die Datenversion ist identisch mit der in dem
-						Tarifprodukt hinterlegten Datenversion
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Komfortklasse" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Rabattklasse" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Mitnahme" type="husst:Mitnahme_Type" maxOccurs="unbounded" minOccurs="0"/>
-			<element name="Teilrelation" type="husst:Teilrelation_Type" maxOccurs="unbounded" minOccurs="0"/>
-
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-
-	<complexType name="Preis_Type">
-		<annotation>
-			<documentation>Wenn keine Preisspalte angegeben ist, wird von der
-				Standardspalte "1" ausgegangen. Ansonsten muss die Nummer der
-				zugehörigen Preisspalte der Datenversorgung angegeben.
-				Die Kennung
-				kann optional die Kennung der Preisspalte enthalten.
-			</documentation>
-		</annotation>
-		<choice>
-			<element name="Betrag" type="husst:Betrag_Type" minOccurs="1" maxOccurs="1"/>
-			<element name="ID_Mwst" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
-			<element name="MwstSatz" maxOccurs="1" minOccurs="1" type="husst:FLOAT1">
-				<annotation>
-					<documentation>
-						Wert zwischen 0 und 100
-					</documentation>
-				</annotation>
-
-			</element>
-
-
-
-		</choice>
-		<attribute name="Verrechnung" type="husst:Preisverrechnung_Type" use="required"/>
-
-
-
-	</complexType>
-
-	<simpleType name="Waehrung_Type">
-		<annotation>
-			<documentation>Währungscode nach ISO 4217.</documentation>
-		</annotation>
-		<restriction base="string">
-			<pattern value="[A-Z]{3}"/>
-		</restriction>
-	</simpleType>
-
-	<simpleType name="Preisverrechnung_Type">
-		<union memberTypes="husst:PreisverrechnungHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="PreisverrechnungHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Basispreis"/>
-			<enumeration value="husst.Abschlag"/>
-			<enumeration value="husst.Zuschlag"/>
-			<enumeration value="husst.Information"/>
-		</restriction>
-	</simpleType>
-
-
-
-
-
-	<complexType name="Beleg_Type">
-		<sequence>
-			<element name="BelegNr" type="int" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						Laufende Aufdrucknummer auf einem Papierdokument oder gespeicherte
-						Folgenummer
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Abschnitt" type="husst:Ausgabeabschnitt_Type" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Zugehörige, unveränderliche Dokumentmerkmale. (Abschnittzähler oder rückseitiger Barcode)</documentation>
-				</annotation>
-			</element>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="Typ" type="husst:BelegTyp_Type" use="required"/>
-
-	</complexType>
-
-	<simpleType name="BelegTyp_Type">
-		<annotation>
-			<documentation></documentation>
-		</annotation>
-		<union memberTypes="husst:BelegTypHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="BelegTypHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Papier"/>
-			<enumeration value="husst.ECard"/>
-			<enumeration value="husst.KACard"/>
-			<enumeration value="husst.BOBCard"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="BezahlArt_Type">
-		<simpleContent>
-			<extension base="husst:BezahlArtSimple_Type">
-				<attribute name="Bezeichnung" type="string" use="optional">
-					<annotation>
-						<documentation>
-							Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
-						</documentation>
-					</annotation>
-				</attribute>
-			</extension>
-		</simpleContent>
-	</complexType>
-
-	<simpleType name="BezahlArtSimple_Type">
-		<union memberTypes="husst:BezahlArtKa_Type husst:ProjektspezifischAnstattKa_Type"/>
-	</simpleType>
-
-	<simpleType name="BezahlArtKa_Type">
-		<annotation>
-			<documentation>
-        Die BezahlArt kommt aus der VDV-KA.
-        Die KA-Werte kommen aus dem EN1545: PaymentMeansCode
-			</documentation>
-		</annotation>
-		<restriction base="husst:INT1">
-			<enumeration value="0">
-				<annotation>
-					<documentation>Keine Angabe</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="1">
-				<annotation>
-					<documentation>Bar</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="3">
-				<annotation>
-					<documentation>Kreditkarte</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="5">
-				<annotation>
-					<documentation>POB/PEB</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="6">
-				<annotation>
-					<documentation>EC-Karte/Lastschrift</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="7">
-				<annotation>
-					<documentation>Rechnung</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="8">
-				<annotation>
-					<documentation>Werteinheiten</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="14">
-				<annotation>
-					<documentation>Gutschein/Voucher</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="17">
-				<annotation>
-					<documentation>ec-Cash</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="24">
-				<annotation>
-					<documentation>Geldkarte</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="25">
-				<annotation>
-					<documentation>Mastercard</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="26">
-				<annotation>
-					<documentation>Visacard</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="27">
-				<annotation>
-					<documentation>HandyTicket Konto</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="28">
-				<annotation>
-					<documentation>Mobilfunkrechnung</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="100">
-				<annotation>
-					<documentation>Amazon Pay</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="101">
-				<annotation>
-					<documentation>Amex</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="102">
-				<annotation>
-					<documentation>Android Pay</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="103">
-				<annotation>
-					<documentation>Apple-Pay</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="104">
-				<annotation>
-					<documentation>(Sonstige) Appbasierte Zahlverfahren</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="105">
-				<annotation>
-					<documentation>Girocard kontaktlos</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="106">
-				<annotation>
-					<documentation>Girogo (GeldKarte kontaktlos)</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="107">
-				<annotation>
-					<documentation>Giropay</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="108">
-				<annotation>
-					<documentation>Maestro</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="109">
-				<annotation>
-					<documentation>Mastercard paypass (kontaktlos)</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="110">
-				<annotation>
-					<documentation>Paydirekt</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="111">
-				<annotation>
-					<documentation>PayPal</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="112">
-				<annotation>
-					<documentation>PrintTicket-Konto</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="113">
-				<annotation>
-					<documentation>Sofortüberweisung</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="114">
-				<annotation>
-					<documentation>V-Pay</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="115">
-				<annotation>
-					<documentation>VISA paywave (kontaktlos)</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="116">
-				<annotation>
-					<documentation>(Sonstige) Web-basierte Zahlverfahren</documentation>
-				</annotation>
-			</enumeration>
-		</restriction>
-	</simpleType>
-
-	<complexType name="Gutscheinbezahlung_Type">
-		<sequence>
-			<element name="GutschId" type="husst:Tarifprodukt_Type" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>Eindeutige Kennung des Gutscheintyps</documentation>
-				</annotation>
-			</element>
-			<element name="Nr" type="string" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-
-	</complexType>
-
-	<simpleType name="Projektspezifisch_Type">
-		<annotation>
-			<documentation>Erlaubt alle Werte, die nicht mit "husst." beginnen.</documentation>
-		</annotation>
-		<restriction base="string">
-			<pattern value="((h[^u])|hu[^s]|hus[^s]|huss[^t]|husst[^\.]|[a-gi-zA-ZöäüÖÄÜß][a-zA-ZöäüÖÄÜß0-9]*)([\-\.][a-zA-ZöäüÖÄÜß0-9]+)*"/>
-		</restriction>
-	</simpleType>
-
-	<simpleType name="AusgabeabschnittTyp_Type">
-		<annotation>
-			<documentation>Beschreibt den Typ eines ausgegebenen Papierdokumentes näher.</documentation>
-		</annotation>
-		<union memberTypes="husst:AusgabeabschnittTypHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="AusgabeabschnittTypHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Fahrschein"/>
-			<enumeration value="husst.Rollenbeginn"/>
-			<enumeration value="husst.Rollenende"/>
-			<enumeration value="husst.Probedruck"/>
-			<enumeration value="husst.Quittung"/>
-			<enumeration value="husst.Beleg"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="Ausgabeabschnitt_Type">
-		<annotation>
-			<documentation>
-				Definiert einen Papierabschnitt mit seiner Startnummer
-				und der Anzahl seiner Barcodeabschnitte oder Abschnittzähler. Die Startnummer
-				ist immer die kleinste Nummer des gelesenen Abschnittes,
-				egal in welche Richtung die Nummerierung der Rolle geht.
-			</documentation>
-		</annotation>
-		<sequence>
-			<element name="StartNr" type="int" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>Startnummer des Abschnittzählers, z.B. Barcode oder anfängliche Rollennummer.</documentation>
-				</annotation>
-			</element>
-			<element name="Anzahl" type="int" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Anzahl der Abschnittzähler, z.B. Barcodes</documentation>
-				</annotation>
-			</element>
-
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="Typ" type="husst:AusgabeabschnittTyp_Type" use="required">
-			<annotation>
-				<documentation>Der Typ des Papierdokumentes</documentation>
-			</annotation>
-		</attribute>
-
-
-	</complexType>
-
-	<simpleType name="GeldBehaeltervorgang_Type">
-		<annotation>
-			<documentation>
-				Übergabemeldung dient zur Registrierung von Safebag-Nummern.
-			</documentation>
-		</annotation>
-		<union memberTypes="husst:GeldBehaeltervorgangHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="GeldBehaeltervorgangHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Anfangsbestand"/>
-			<enumeration value="husst.Endbestand"/>
-			<enumeration value="husst.Behaelterzufuehrung"/>
-			<enumeration value="husst.Behaelterentnahme"/>
-			<enumeration value="husst.Bestandsaufnahme"/>
-			<enumeration value="husst.Befuellung"/>
-			<enumeration value="husst.Entnahme"/>
-			<enumeration value="husst.Uebergabemeldung"/>
-			<enumeration value="husst.Entnahmemeldung"/>
-			<enumeration value="husst.Geldabwurf"/>
-		</restriction>
-	</simpleType>
-
-
-	<complexType name="Zaehldaten_Type">
-		<sequence>
-			<element name="Einsteiger" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
-			<element name="Aussteiger" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
-			<element name="Fehler" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-		<attribute name="Kennung" type="int" use="required">
-			<annotation>
-				<documentation>Die spezielle Bezeichnung dieser Zähldatneinheit
-				</documentation>
-			</annotation>
-		</attribute>
-
-
-
-	</complexType>
-
-
-
-
-
-
-	<complexType name="Schichtabschluss_Type">
-		<annotation>
-			<documentation>Der Datensatz zum Schichtabschluss. Dieser Datensatz
-				muss paarweise mit Schichtbeginn vorkommen.</documentation>
-		</annotation>
-		<sequence>
-			<element name="Ausloeser" type="husst:Ausloeser_Type" minOccurs="1" maxOccurs="1"/>
-			<element name="Beleg" type="husst:Beleg_Type" minOccurs="0" maxOccurs="unbounded"/>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-
-	</complexType>
-
-	<complexType name="Lastschrift_Type">
-		<sequence>
-			<element name="BLZ-BIC" type="string" maxOccurs="1" minOccurs="1"/>
-			<element name="Konto-IBAN" type="string" maxOccurs="1" minOccurs="1"/>
-			<element name="KartenfolgeNr" type="int" maxOccurs="1" minOccurs="1"/>
-			<element name="Kartenart" type="int" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>1=ec-Karte Magnetstreifen</documentation>
-				</annotation>
-			</element>
-			<element name="GueltigBis" type="gYearMonth" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>Gültigendejahr der Karte</documentation>
-				</annotation>
-			</element>
-			<element name="Unterschrift" type="boolean" maxOccurs="1" minOccurs="1"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Schichtsummen_Type">
-		<choice>
-			<element name="Kassenliste" type="husst:Kassenliste_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="BelegKassenliste" type="husst:Belegkassenliste_Type" maxOccurs="1" minOccurs="0"/>
-		</choice>
-	</complexType>
-
-	<complexType name="Kasse_Type">
-		<sequence>
-			<element name="Betrag" type="husst:Betrag_Type" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						Kassenstand in kleinster Waehrungseinheit (z.B. Cent, Rappen, etc.)
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Zahlart" type="husst:BezahlArt_Type" maxOccurs="1" minOccurs="1"/>
-		</sequence>
-	</complexType>
-
-	<simpleType name="KasseTyp_Type">
-		<annotation>
-			<documentation></documentation>
-		</annotation>
-		<union memberTypes="husst:KasseTypHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="KasseTypHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.bar"/>
-			<enumeration value="husst.unbar"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="Belegkasse_Type">
-		<sequence>
-			<element name="Betrag" type="husst:Betrag_Type" minOccurs="0" maxOccurs="1">
-				<annotation>
-					<documentation>
-						Hier kann der Gesamtbetrag der vereinnahmten
-						Belege eingetragen werden
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Gutschrift" type="husst:Tarifprodukt_Type" minOccurs="0" maxOccurs="1"/>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="Typ" type="husst:BelegkasseTyp_Type" use="required"/>
-		<attribute name="Anzahl" type="int" use="required"/>
-	</complexType>
-
-	<simpleType name="BelegkasseTyp_Type">
-		<annotation>
-			<documentation></documentation>
-		</annotation>
-		<union memberTypes="husst:BelegkasseTypHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="BelegkasseTypHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Restgeldquittung"/>
-			<enumeration value="husst.Stornierung"/>
-			<enumeration value="husst.Gutschein"/>
-			<enumeration value="husst.Ruecknahme"/>
-			<enumeration value="husst.Chipkarte"/>
-			<enumeration value="husst.Flugcoupon"/>
-			<enumeration value="husst.Anfahrtscoupon"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="SchichtListe_Type">
-		<choice>
-			<element name="Schicht" type="husst:Schicht_Type" minOccurs="0" maxOccurs="unbounded"/>
-		</choice>
-	</complexType>
-
-
-	<complexType name="Transaktionsliste_Type">
-		<sequence>
-			<element name="Transaktion" type="husst:Transaktion_Type" minOccurs="0" maxOccurs="unbounded"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Zahlungsliste_Type">
-		<sequence>
-			<element name="Zahlung" type="husst:Zahlung_Type" minOccurs="0" maxOccurs="unbounded"/>
-		</sequence>
-	</complexType>
-
-
-	<complexType name="Zaehldatenliste_Type">
-		<sequence>
-			<element name="Zaehldaten" type="husst:Zaehldaten_Type" minOccurs="0" maxOccurs="unbounded"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Kassenliste_Type">
-		<sequence>
-			<element name="Kasse" type="husst:Kasse_Type" minOccurs="0" maxOccurs="unbounded"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Belegkassenliste_Type">
-		<sequence>
-			<element name="BelegKasse" type="husst:Belegkasse_Type" minOccurs="0" maxOccurs="unbounded"/>
-		</sequence>
-	</complexType>
-
-
-
-	<complexType name="Dienstende_Type">
-		<sequence>
-			<element name="Vertriebsstelle" type="husst:Vertriebsstelle_Type" maxOccurs="unbounded" minOccurs="1"/>
-			<element name="Beleg" type="husst:Beleg_Type" minOccurs="0" maxOccurs="unbounded"/>
-			<element name="Kassenliste" type="husst:Kassenliste_Type" minOccurs="1" maxOccurs="1"/>
-			<element name="Belegkassenliste" type="husst:Belegkassenliste_Type" minOccurs="1" maxOccurs="1"/>
-			<element name="Bargeldbilanz" type="husst:Bargeldbilanz_Type" minOccurs="0" maxOccurs="1"/>
-
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="DienstNr" type="int" use="required"/>
-	</complexType>
-
-
-	<complexType name="Geldbehaelterliste_Type">
-		<annotation>
-			<documentation>notiert die Geldwerte oder sonstige Werte (Gutscheine, Stornierungsbelege, ...) bezogen auf einen Vorgangszeitpunkt</documentation>
-		</annotation>
-		<sequence>
-			<element name="Vorgang" type="husst:GeldBehaeltervorgang_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Geldbehaelter" type="husst:Geldbehaelter_Type" minOccurs="0" maxOccurs="unbounded"/>
-			<element name="Wertbehaelter" type="husst:Wertbehaelter_Type" maxOccurs="unbounded" minOccurs="0"/>
-			<element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="DienstNr" type="int" use="required">
-			<annotation>
-				<documentation></documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-	<complexType name="Geldbehaelter_Type">
-		<sequence>
-			<element name="Stueck" type="husst:Stuecke_Type" minOccurs="0" maxOccurs="unbounded"/>
-			<element name="Wert" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-		<attribute name="Typ" type="husst:GeldbehaelterTyp_Type"/>
-		<attribute name="Nr" type="int">
-			<annotation>
-				<documentation>Behälternummer</documentation>
-			</annotation>
-		</attribute>
-		<attribute name="PhysPosition" type="int" use="optional">
-			<annotation>
-				<documentation>Die physikalische Position
-				</documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-	<complexType name="Geraet_Type">
-		<sequence>
-			<element name="Name" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Der Name ist ein beliebiger, sprechender Name des
-						Gerätes. (z.B. Busdrucker-1234).
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Id" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Eindeutige Kennung eines Bestandteils der
-						Gerätehardware (z.B. die MAC der Netzwerkhardware.) Welche Kennung
-						das ist, muss von
-						der Gerätesoftware entschieden werden. Das
-						Element ist optional.
-					</documentation>
-				</annotation>
-			</element>
-		</sequence>
-		<attribute name="Typ" type="string" use="required">
-			<annotation>
-				<documentation>Der Gerätetyp entspricht den Anwendern bekannten und
-					vorgegebenen Namen.
-					Die Liste der Gerätetypen kann
-					beliebig erweitert werden.
-				</documentation>
-			</annotation>
-		</attribute>
-		<attribute name="Nr" type="int" use="required">
-			<annotation>
-				<documentation>Die Nummer entspricht der dem Anwender bekannten
-					Gerätenummer.
-					Die Nummer ist nur zusammen mit der Angabe eines
-					Mandanten eindeutig.
-				</documentation>
-			</annotation>
-		</attribute>
-		<attribute name="Mandant" type="int" use="required">
-			<annotation>
-				<documentation>Die Gerätenummer ist nur zusammen mit einem
-					zugeordneten Mandant eindeutig.
-					Der Standard-Mandant ist '1'.
-				</documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-	<complexType name="Komponentenliste_Type">
-		<sequence>
-			<element name="Vorgang" type="husst:KomponentenVorgang_Type"/>
-			<element name="Komponente" type="husst:Komponente_Type" minOccurs="0" maxOccurs="unbounded"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Komponente_Type">
-		<sequence>
-			<element name="Name" type="string" minOccurs="1" maxOccurs="1"/>
-			<element name="Version" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Variante" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="SerienNr" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="PhysPosition" type="int" maxOccurs="1" minOccurs="0"/>
-			<element name="ErstellZeitPunkt" type="dateTime" maxOccurs="1" minOccurs="0"/>
-			<element name="Hersteller" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Komponente" type="husst:Komponente_Type" minOccurs="0" maxOccurs="unbounded"/>
-		</sequence>
-		<attribute name="Klasse" type="husst:KomponentenKlasse_Type" use="required"/>
-	</complexType>
-
-	<simpleType name="KomponentenKlasse_Type">
-		<union memberTypes="husst:KomponentenKlasseHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="KomponentenKlasseHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Software"/>
-			<enumeration value="husst.Hardware"/>
-			<enumeration value="husst.Daten"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="Standort_Type">
-		<annotation>
-			<documentation></documentation>
-		</annotation>
-		<sequence>
-			<element name="Typ" type="husst:OrtsTyp_Type" minOccurs="1" maxOccurs="1">
-				<annotation>
-					<documentation>
-						Mit dem Typ wird die Ausprägung des jeweilgen
-						Standorts unterschieden.
-						Die Standorte eines Typs und eines
-						Mandanten sind fortlaufend
-						durchnumeriert.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Name" type="string" minOccurs="0" maxOccurs="1">
-				<annotation>
-					<documentation>Der Name ist ein beliebiger, sprechender Name des
-						Standorts.</documentation>
-				</annotation>
-			</element>
-		</sequence>
-		<attribute name="Nr" type="int">
-			<annotation>
-				<documentation>Nummer des Nutzungsortes des Gerätes zu dem notierten
-					Zeitpunkt.
-					Die Nummer ist dem jeweiligen Anwender bekannt.
-					Das kann
-					eine Fahrzeugnummer sein, oder ein Kiosknummer,
-					eine
-					Haltestellennummer oder eine Bahnhofsnummer abhängig von den
-					Projektvorgaben und definiert vom jeweiligen Mandanten sein.
-					Die
-					Nummer ist nur zusammen mit der Angabe eines Mandanten eindeutig.
-				</documentation>
-			</annotation>
-		</attribute>
-		<attribute name="Mandant" type="int" use="optional">
-			<annotation>
-				<documentation>Die Standortnummer ist nur zusammen mit einem
-					zugeordneten Mandant eindeutig.
-					Der Standard-Mandant ist '1'.
-				</documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-	<complexType name="Tarifprodukt_Type">
-		<sequence>
-			<element name="ID_Tarifgebiet" type="husst:INT4" maxOccurs="1" minOccurs="1"/>
-			<element name="ID_Sorte" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
-
-
-			<element name="ReferenzExternSorte" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="ID_Preisstufe" type="husst:INT4" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-                       Die Preisstufe ist nur zusammen mit dem Tarifgebiet gültig.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="ReferenzExternPreisstufe" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="ID_Preis" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
-			<element name="ReferenzExternPreis" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="ID_Preisspalte" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-
-		<attribute name="DatenversionInhalt" type="string" use="required">
-			<annotation>
-				<documentation>Der Inhalt von "DatenversionInhalt" der Tabelle VersionInhalt der Versorgung</documentation>
-			</annotation>
-		</attribute>
-		<attribute name="DatenversionZeitraum" type="string" use="required">
-			<annotation>
-				<documentation>Als DatenversionZeitraum wird das Feld "DatenversionZeitraum" des zum Verkaufszeitpunkt gültigen Zeitraum-Eintrages mit der höchsten SubZeitraumNr geliefert.</documentation>
-			</annotation>
-		</attribute>
-
-
-	</complexType>
-
-	<complexType name="Betrag_Type">
-		<sequence>
-			<element name="Waehrung" type="husst:Waehrung_Type"/>
-			<element name="Betrag" type="int">
-				<annotation>
-					<documentation>Betrag in kleinsten Währungseinheiten (z.B. Euro-Cent)
-					</documentation>
-				</annotation>
-			</element>
-		</sequence>
-
-
-	</complexType>
-
-	<simpleType name="GeldbehaelterTyp_Type">
-		<union memberTypes="husst:GeldbehaelterTypHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="GeldbehaelterTypHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Personenkasse"/>
-			<enumeration value="husst.Muenzendkasse"/>
-			<enumeration value="husst.Banknotenendkasse"/>
-			<enumeration value="husst.Geldwechsler"/>
-			<enumeration value="husst.Geldspeicher"/>
-			<enumeration value="husst.Zwischenkasse"/>
-			<enumeration value="husst.Wertbehaelter"/>
-			<enumeration value="husst.Handkasse"/>
-		</restriction>
-	</simpleType>
-
-
-
-	<element name="Schichten" type="husst:Schichtenliste_Type"/>
-
-	<complexType name="Schicht_Type">
-		<sequence>
-			<element name="Datensatz" type="husst:Datensatz_Type" maxOccurs="unbounded" minOccurs="0">
-				<annotation>
-					<documentation>
-						Jede Schicht enthält 2 bis n Datensätze. Für
-						eine
-						ordentliche Schicht sollten mindestens die
-						Datensätze Schichtbeginn
-						und Schichtabschluss
-						enthalten sein.
-					</documentation>
-				</annotation>
-			</element>
-		</sequence>
-		<attribute name="SchichtUID" type="string" use="required">
-			<annotation>
-				<documentation>
-					Diese UID ist eine eindeutiger Wert, der (mit
-					höchster Wahrscheinlichkeit) nur EINMALIG für ALLE
-					GERÄTE ZU ALLEN
-					ZEITPUNKTEN AN ALLEN ORTEN existiert
-					(Zeit und Raum-Doppler
-					ausgenommmen ;-). ALLE Daten
-					EINER Schicht eines Gerätes werden mit
-					dieser ID
-					gekennzeichnet. Die Generierungsvorschrift ist
-					beliebig,
-					solange die obigen Bedingungen eingehalten
-					werden. Beispiel: uuidgen
-					unter Linux, uuidgen.exe
-					unter Windows
-				</documentation>
-			</annotation>
-		</attribute>
-		<attribute name="Projekt" type="string" use="optional">
-			<annotation>
-				<documentation>
-					Dies ist eine vom Projektierer vorgegebene
-					Projektkennzeichnung, z.B. "MENT"
-
-				</documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-	<complexType name="Schichtbeginn_Type">
-		<annotation>
-			<documentation>Der Datensatz zum Schichtbeginn. Dieser Datensatz muss
-				paarweise mit Schichtabschluss vorkommen.
-			</documentation>
-		</annotation>
-		<sequence>
-			<element name="SchichtNr" type="int" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						Diese Schichtnummer enstpricht der den Anwendern
-						bekannte Schichtnummer. In der Regel wird nach
-						dieser Nummer ausgewertet und die Nummer wird
-						auf Belege aufgedruckt. Die Schichtnummer ist
-						mindestens für jede Schicht-UUID eindeutig. Die
-						Schichtnummer sollte inkrementierend aufsteigen
-						und nie '0' sein.
-
-						Achtung: Schichtnummer vs. Dienstnummer:
-						Innerhalb einer Schicht können mehrere Dienste
-						auch gleichzeitig ablaufen. Kein Dienst
-						überlappt zeitlich eine Schichtgrenze. Dienste
-						sind in der Regel Personen-(Konten) oder
-						Geräte-(Konten) zugeordnet. Schichten sind nur
-						ein Behälter für Dienste.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Geraet" type="husst:Geraet_Type" minOccurs="1" maxOccurs="1">
-				<annotation>
-					<documentation>
-						Dieser Datensatz kennzeichnet das technische
-						Gerät, das die Datensätze dieser Schicht
-						erzeugt.
-					</documentation>
-				</annotation>
-			</element>
-
-			<element name="Betriebsart" type="husst:Betriebsart_Type" minOccurs="1" maxOccurs="1">
-				<annotation>
-					<documentation>
-						Dieses Feld unterscheidet die Datensätze dieser
-						Schicht in Echt- und sonstigen Betrieb.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Standort" type="husst:Standort_Type" minOccurs="0" maxOccurs="1">
-				<annotation>
-					<documentation>
-						Dieses Feld bezeichnet den Standort zum
-						Schichtbeginn.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Pruefbeginn_Type">
-		<sequence>
-			<element name="Kleidung" type="husst:Pruefkleidung_Type" minOccurs="0" maxOccurs="1">
-				<annotation>
-					<documentation>
-						Die vom Prüfer getragene Kleidung
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Pruefart" type="husst:Pruefart_Type" minOccurs="0" maxOccurs="1">
-				<annotation>
-					<documentation>Die Art der Prüfung</documentation>
-				</annotation>
-			</element>
-			<element name="Pruefer" type="string" minOccurs="0" maxOccurs="unbounded">
-				<annotation>
-					<documentation>
-						Beteiligte Prüfer (Nummer)
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Linie" type="int" minOccurs="0" maxOccurs="1">
-				<annotation>
-					<documentation>Liniennummer</documentation>
-				</annotation>
-			</element>
-			<element name="Verkehrsmittel" type="husst:TransportserviceArt_Type" minOccurs="0" maxOccurs="1">
-				<annotation>
-					<documentation>Verkehrsmittel</documentation>
-				</annotation>
-			</element>
-			<element name="Einstieg" type="husst:Transaktionsort_Type" minOccurs="0" maxOccurs="1">
-				<annotation>
-					<documentation>Einstiegshaltestelle</documentation>
-				</annotation>
-			</element>
-			<element name="Richtung" type="husst:Transaktionsort_Type" minOccurs="0" maxOccurs="1">
-				<annotation>
-					<documentation>Eine Richtungsangabe</documentation>
-				</annotation>
-			</element>
-			<element name="AnzahlFahrgaeste" type="int" minOccurs="0" maxOccurs="1">
-				<annotation>
-					<documentation>
-						Eine Abschätzung der Anzahl der Fahrgäste bei
-						Einstieg
-					</documentation>
-				</annotation>
-			</element>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="DienstNr" type="int" use="required"/>
-		<attribute name="PruefNr" type="int" use="required">
-			<annotation>
-				<documentation></documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-	<complexType name="Pruefabschluss_Type">
-		<sequence>
-			<element name="Ausstieg" type="husst:Transaktionsort_Type" minOccurs="0" maxOccurs="1">
-				<annotation>
-					<documentation>Ausstiegshaltestelle</documentation>
-				</annotation>
-			</element>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="DienstNr" type="int" use="required"/>
-		<attribute name="PruefNr" type="int" use="required">
-			<annotation>
-				<documentation></documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-	<simpleType name="Pruefkleidung_Type">
-		<union memberTypes="husst:PruefkleidungHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="PruefkleidungHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Zivilkleidung"/>
-			<enumeration value="husst.Dienstkleidung"/>
-			<enumeration value="husst.Sonstiges"/>
-		</restriction>
-	</simpleType>
-
-	<simpleType name="Pruefart_Type">
-		<union memberTypes="husst:PruefartHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="PruefartHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Standardpruefung"/>
-			<enumeration value="husst.Abgangskontrolle"/>
-			<enumeration value="husst.Sonstiges"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="TransportserviceArt_Type">
-		<simpleContent>
-			<extension base="husst:TransportserviceArtSimple_Type">
-				<attribute name="Bezeichnung" type="string" use="optional">
-					<annotation>
-						<documentation>
-							Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
-						</documentation>
-					</annotation>
-				</attribute>
-			</extension>
-		</simpleContent>
-	</complexType>
-
-	<simpleType name="TransportserviceArtSimple_Type">
-		<union memberTypes="husst:TransportserviceArtKa_Type husst:ProjektspezifischAnstattKa_Type"/>
-	</simpleType>
-
-	<simpleType name="TransportserviceArtKa_Type">
-		<annotation>
-			<documentation>
+  <complexType name="TransportserviceArt_Type">
+    <simpleContent>
+      <extension base="husst:TransportserviceArtSimple_Type">
+        <attribute name="Bezeichnung" type="string" use="optional">
+          <annotation>
+            <documentation>
+              Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
+            </documentation>
+          </annotation>
+        </attribute>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <simpleType name="TransportserviceArtSimple_Type">
+    <union memberTypes="husst:TransportserviceArtKa_Type husst:ProjektspezifischAnstattKa_Type"/>
+  </simpleType>
+  <simpleType name="TransportserviceArtKa_Type">
+    <annotation>
+      <documentation>
         Die TransportserviceArt kommt aus der VDV-KA.
         Die KA-Werte kommen aus dem EN1545: TransportTypeCode
-			</documentation>
-		</annotation>
-		<restriction base="husst:INT1">
-			<enumeration value="0">
-				<annotation>
-					<documentation>nicht spezifiziert/unbestimmt</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="1">
-				<annotation>
-					<documentation>Linienbus im Stadtverkehr</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="3">
-				<annotation>
-					<documentation>Metro/U-Bahn/S-Bahn</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="4">
-				<annotation>
-					<documentation>Strassenbahn/TRAM</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="6">
-				<annotation>
-					<documentation>Schiff</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="10">
-				<annotation>
-					<documentation>ICE</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="11">
-				<annotation>
-					<documentation>Überlandbus/Regionalbus</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="19">
-				<annotation>
-					<documentation>Regionalzug</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="20">
-				<annotation>
-					<documentation>IC</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="21">
-				<annotation>
-					<documentation>Standseilbahn</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="29">
-				<annotation>
-					<documentation>Regionalexpress</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="30">
-				<annotation>
-					<documentation>Expressbus</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="31">
-				<annotation>
-					<documentation>Flughafenzubringer</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="32">
-				<annotation>
-					<documentation>Verbundnahverkehr</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="33">
-				<annotation>
-					<documentation>Verbundnahverkehr ohne Kurzstrecke</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="34">
-				<annotation>
-					<documentation>SPNV</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="35">
-				<annotation>
-					<documentation>Verbundnahverkehr ohne Sonderverkehrsmittel</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="36">
-				<annotation>
-					<documentation>Fähre</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="37">
-				<annotation>
-					<documentation>Bergbahn</documentation>
-				</annotation>
-			</enumeration>
-		</restriction>
-	</simpleType>
-
-	<complexType name="Dienstbeginn_Type">
-		<sequence>
-			<element name="Vertriebsstelle" type="husst:Vertriebsstelle_Type" minOccurs="1" maxOccurs="unbounded">
-				<annotation>
-					<documentation>
-						Der Dienstbeginn kann gleichzeitig auf mehrere
-						Vertriebsstellen bezogen sein. Hiermit besteht
-						beispielsweise die Möglichkeit geichzeitig auf
-						den Verkäufer und die Verkaufsstelle zu
-						beziehen.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="DienstPlanNr" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Die laufende Bezeichnung des Dienstplans des
-						Gerätebedieners.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="DienstNr" type="int" use="required">
-			<annotation>
-				<documentation>Diese Dienstnummer enstpricht der den Anwendern
-					bekannte Dienstnummer.
-					In der Regel wird nach dieser Nummer
-					ausgewertet und die Nummer wird
-					auf Belege aufgedruckt.
-					Die
-					Dienstnummer ist mindestens für jede Schicht eindeutig. Eine
-					Schicht kann viele Dienste enthalten.
-					Die Dienstnummer sollte
-					inkrementierend aufsteigen und nie '0' sein.
-
-					Achtung: Schichtnummer
-					vs. Dienstnummer:
-					Innerhalb einer Schicht können mehrere Dienste
-					auch gleichzeitig ablaufen.
-					Kein Dienst überlappt zeitlich
-					eine
-					Schichtgrenze. Dienste sind in der Regel Personen-(Konten) oder
-					Geräte-(Konten) zugeordnet.
-					Schichten sind nur ein Behälter für
-					Dienste und sonstige Informationen, die
-					keinem Dienst zugeordnet
-					sind.
-
-				</documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-	<simpleType name="Betriebsart_Type">
-		<union memberTypes="husst:BetriebsartHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="BetriebsartHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Echtbetrieb"/>
-			<enumeration value="husst.Testbetrieb"/>
-			<enumeration value="husst.Schulungsbetrieb"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="OrtsTyp_Type">
-		<simpleContent>
-			<extension base="husst:OrtsTypSimple_Type">
-				<attribute name="Bezeichnung" type="string" use="optional">
-					<annotation>
-						<documentation>
-							Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
-						</documentation>
-					</annotation>
-				</attribute>
-			</extension>
-		</simpleContent>
-	</complexType>
-
-	<simpleType name="OrtsTypSimple_Type">
-		<union memberTypes="husst:OrtsTypKa_Type husst:ProjektspezifischAnstattKa_Type"/>
-	</simpleType>
-
-	<simpleType name="OrtsTypKa_Type">
-		<annotation>
-			<documentation>
-        Der OrtsTyp kommt aus der VDV-KA.
-        Die KA-Werte kommen aus dem EN1545: LocationTypeCode
-			</documentation>
-		</annotation>
-		<restriction base="husst:INT1">
-			<enumeration value="0">
-				<annotation>
-					<documentation>Bushaltestelle</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="1">
-				<annotation>
-					<documentation>U-Bahn- (Metro-)Station</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="2">
-				<annotation>
-					<documentation>Bahnhof (Eisenbahn)</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="3">
-				<annotation>
-					<documentation>Strassenbahn- (TRAM-) Haltestelle</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="11">
-				<annotation>
-					<documentation>Verkaufsstelle</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="16">
-				<annotation>
-					<documentation>Gebiet(auch fuer Zone)</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="17">
-				<annotation>
-					<documentation>Korridor</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="200">
-				<annotation>
-					<documentation>
-            Haltestelle allgemein
-            fuer Haltestellen im Fahrplansinne,
-            unabhaengig vom Verkehrsmittel
-					</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="201">
-				<annotation>
-					<documentation>Massenpersonalisierer</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="202">
-				<annotation>
-					<documentation>areaList_ID</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="203">
-				<annotation>
-					<documentation>im Fahrzeug/Zug</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="204">
-				<annotation>
-					<documentation>TouchPoint</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="205">
-				<annotation>
-					<documentation>im Fahrzeug der Linie</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="206">
-				<annotation>
-					<documentation>im Fahrzeug der Zugnummer</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="207">
-				<annotation>
-					<documentation>Teilzone</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="208">
-				<annotation>
-					<documentation>neutrale Zone</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="209">
-				<annotation>
-					<documentation>Wabe</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="210">
-				<annotation>
-					<documentation>Grosswabe</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="211">
-				<annotation>
-					<documentation>Tarifpunkt</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="212">
-				<annotation>
-					<documentation>Backoffice</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="213">
-				<annotation>
-					<documentation>im Fahrzeug an Haltestelle</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="214">
-				<annotation>
-					<documentation>Ereignisort (event location)</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="215">
-				<annotation>
-					<documentation>Ticketserver</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="251">
-				<annotation>
-					<documentation>Ortsteil</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="252">
-				<annotation>
-					<documentation>Gemeinde</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="253">
-				<annotation>
-					<documentation>Kreis</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="254">
-				<annotation>
-					<documentation>Land</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="255">
-				<annotation>
-					<documentation>keine Angabe</documentation>
-				</annotation>
-			</enumeration>
-		</restriction>
-	</simpleType>
-
-	<complexType name="EinsatzTyp_Type">
-		<sequence>
-			<element name="Name" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Der Name ist ein beliebiger, sprechender Name des
-						Einsatztyps (z.B. Vorverkauf, Bereich Hamburg Mitte).
-					</documentation>
-				</annotation>
-			</element>
-		</sequence>
-		<attribute name="Nr" type="int">
-			<annotation>
-				<documentation>Einsatztypen unterscheiden im Gegensatz zu Geräten
-					den jeweiligen Einsatz des Gerätes.
-					So kann ein gleiches technisches
-					Gerät sowohl mobil als auch
-					stationär mit unterschiedlichen
-					Ausprägungen betrieben werden.
-
-					Die Einsatztypennummer entspricht der
-					dem Anwender bekannten
-					Einsatztypennummer.
-					Der Standard-Einsatztyp
-					ist '1'.
-
-					Die Einsatztypennummer ist nur zusammen mit der Angabe
-					eines Mandanten
-					eindeutig. </documentation>
-			</annotation>
-		</attribute>
-		<attribute name="Mandant" type="int">
-			<annotation>
-				<documentation>Die Einsatztypennummer ist nur zusammen mit einem
-					zugeordneten Mandant eindeutig.
-					Der Standard-Mandant ist '1'.
-				</documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-
-	<simpleType name="KomponentenVorgang_Type">
-		<union memberTypes="husst:KomponentenVorgangHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="KomponentenVorgangHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Entnahme"/>
-			<enumeration value="husst.Zufuehrung"/>
-			<enumeration value="husst.Bestandsaufnahme"/>
-			<enumeration value="husst.Update"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="Stuecke_Type">
-		<sequence>
-			<element name="Anzahl" type="int" maxOccurs="1" minOccurs="1"/>
-			<element name="StueckWert" type="husst:Betrag_Type" maxOccurs="1" minOccurs="1"/>
-		</sequence>
-	</complexType>
-
-
-	<complexType name="Kontrolldaten_Type">
-		<annotation>
-			<documentation></documentation>
-		</annotation>
-		<sequence>
-			<element name="Typ" maxOccurs="1" minOccurs="1" type="string">
-				<annotation>
-					<documentation>Kontrollmeldungen beliebiger Art z. B. Chipkartenkontrolle für KA-Berechtigung, DB-Online-Ticket, BOB-Ticket, DF-Fahrschein, ...</documentation>
-				</annotation>
-			</element>
-			<element name="Kontrolldaten" type="husst:Any_Type" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-
-					</documentation>
-				</annotation>
-			</element>
-			<choice>
-				<element name="KAReferenz" type="husst:KAReferenz_Type" maxOccurs="1" minOccurs="0">
-					<annotation>
-						<documentation>
-							Referenz zu einem global eindeutigen Vorgang
-							- diese Information ist auch in den
-							zugehörigen KA Kontrolldaten enthalten.
-						</documentation>
-					</annotation>
-				</element>
-				<element name="Referenz" type="string" maxOccurs="1" minOccurs="0">
-					<annotation>
-						<documentation>
-							Referenz zu einem global eindeutigen Vorgang
-							- diese Information ist auch in den
-							zugehörigen Transaktionsdaten als
-							Eindeutigkeitskennzeichen enthalten.
-						</documentation>
-					</annotation>
-				</element>
-			</choice>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="DienstNr" type="int" use="required"/>
-	</complexType>
-
-
-	<complexType name="Vertriebsstelle_Type">
-		<sequence>
-			<element name="Typ" maxOccurs="1" minOccurs="1" type="husst:OrtsTyp_Type">
-				<annotation>
-					<documentation>
-						Der Typ qualifiziert die beiden Elemente
-						'Mandant' und 'Nr'.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Mandant" type="int" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						Der Mandant qualifiziert eindeutig die
-						Zugehörigkeit der 'Nr'.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Nr" type="int" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						Hier wird, je nach ktVerkaufsstellenType, die
-						Personalnummer, die Verkaufsstellennummer, die
-						Gerätenummer etc. hinterlegt. Die Nummer ist nur
-						in Beziehung zu Mandant und dem Typ eindeutig.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Transaktionsdaten_Type">
-		<sequence>
-			<element name="Transaktionsart" maxOccurs="1" minOccurs="1" type="husst:Transaktionsart_Type"/>
-			<element name="Transaktionsdaten" type="husst:Any_Type" maxOccurs="1" minOccurs="1"/>
-			<choice>
-				<element name="KAReferenz" type="husst:KAReferenz_Type" maxOccurs="1" minOccurs="0">
-					<annotation>
-						<documentation>
-							Referenz zu einem global eindeutigen Vorgang
-							- diese Information ist auch in den
-							zugehörigen KA Kontrolldaten enthalten.
-						</documentation>
-					</annotation>
-				</element>
-				<element name="Referenz" type="string" maxOccurs="1" minOccurs="0">
-					<annotation>
-						<documentation>
-							Referenz zu einem global eindeutigen Vorgang
-							- diese Information ist auch in den
-							zugehörigen Kontrolldaten als
-							Eindeutigkeitskennzeichen enthalten.
-						</documentation>
-					</annotation>
-				</element>
-			</choice>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Bargeldbilanz_Type">
-		<annotation>
-			<documentation>Für jede vorkommende Währung werden hier die Bilanzen
-				über den Dienst, der bei Automaten gleiche mit der Schicht ist,
-				aufgeführt. Die zugehörigen Bargeld-Einnahmen finden sich in der
-				Kassenliste.</documentation>
-		</annotation>
-		<sequence>
-			<element name="Anfangsbestand" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="1"/>
-			<element name="Zufuehrungen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
-			<element name="Entnahmen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
-			<element name="Fehleinnahmen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
-			<element name="Kassenentnahmen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
-			<element name="Endbestand" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="1"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="EBEErfassung_Type">
-		<sequence>
-			<choice>
-				<element name="BezugsNr" type="string" maxOccurs="1" minOccurs="1">
-					<annotation>
-						<documentation>
-							Eine eindeitige ID dieses EBE-Vorgangs, es
-							könnte bei Verkaufsgeräten die UID sein, bei
-							Nacherfassung muss die ID vom Bediener
-							versorgt werden.
-						</documentation>
-					</annotation>
-				</element>
-			</choice>
-			<element name="EBEVorgang" type="husst:EBEVorgang_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
-			<element name="Merkmale" type="husst:EBEMerkmale_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Kundendaten" type="husst:Kundendaten_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="Verfolgung" type="husst:Verfolgung_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="DienstNr" type="int" use="required"/>
-	</complexType>
-
-	<complexType name="Kundendaten_Type">
-		<sequence>
-			<element name="Fahrgast" type="husst:Person_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Erzieher" type="husst:Person_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-
-	<complexType name="Verfolgung_Type">
-		<sequence>
-			<element name="Typ" type="husst:VerfolgungsTyp_Type" maxOccurs="unbounded" minOccurs="1"/>
-			<element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="EBEVorgang_Type">
-		<sequence>
-			<element name="Typ" type="husst:VorgangsTyp_Type" maxOccurs="unbounded" minOccurs="1"/>
-			<element name="Beanstandung" type="string" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						Entspricht der vorgegebenen Codierung z.B. der
-						Bahn, in der Regel eine zweistellige Ziffer.
-
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Begruendung" type="string" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						Der Grund der Beanstandung (zB. nicht lesbar, vermutlich verfälscht, Tarif ungültig, ohne Kundenkarte etc.)
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Forderung" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="Referenzbetrag" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="EBEMerkmale_Type">
-		<sequence>
-			<element name="Ort" type="husst:Transaktionsort_Type" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-
-						Eine Erfassung des Vorgangsorts.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="VorfallsOrtNotiz" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Eine textuelle Beschreibung des Vorfallsorts.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="KomfortKlasse" type="int" maxOccurs="1" minOccurs="0"/>
-			<element name="Fahrausweisart" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Wenn ein Fahrausweis vorgezeigt wurde, welcher
-						Art
-					</documentation>
-				</annotation>
-			</element>
-			<element name="FahrausweisNr" type="int" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Die Nummer (laufende Nummer) des Fahrausweises
-					</documentation>
-				</annotation>
-			</element>
-			<element name="FahrausweisEingezogen" type="boolean" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Wird auf true gesetzt, wenn der Fahrausweis
-						eingezogen wurde.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="FahrausweisAbholung" type="date" maxOccurs="1" minOccurs="0"/>
-			<element name="Bearbeitungsstelle" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="EinstiegsHaltestelle" type="int" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Die IBNR</documentation>
-				</annotation>
-			</element>
-			<element name="EinstiegNotiz" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Eine textuelle Beschreibung zum Einstieg
-					</documentation>
-				</annotation>
-			</element>
-			<element name="ZielHaltestelle" type="int" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Die IBNR</documentation>
-				</annotation>
-			</element>
-			<element name="ZielNotiz" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Eine textuelle Beschreibung zum Fahrtziel bzw.
-						Ausstieg
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Codierung" type="husst:Codierung_Type" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						Eine Codierung zur Angabe des Grunds zum
-						EBE-Fall
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Sitzplatz" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Ein Hinweis, wo der EBE-Fall angetroffen wurde
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Verhalten" type="string" maxOccurs="unbounded" minOccurs="0">
-				<annotation>
-					<documentation>
-						Bemerkungen zu Verhalten des EBE-Falls.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Polizei" type="husst:Polizei_Type" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Wenn Polizei hinzugezogen wurde, von welchem
-						Revier.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Linie" type="int" maxOccurs="1" minOccurs="0"/>
-			<element name="Kurs" type="int" maxOccurs="1" minOccurs="0"/>
-			<element name="Verbundkennung" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="ZVTBezahlung_Type">
-		<sequence>
-			<element name="Kartenherausgeber" type="husst:BezahlArt_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="TerminalId" type="string" maxOccurs="1" minOccurs="1"/>
-			<element name="TransaktionsNr" type="string" maxOccurs="1" minOccurs="1"/>
-			<element name="Zeitpunkt" type="dateTime" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Barbezahlung_Type">
-		<sequence>
-			<element name="Einnahme" type="husst:Betrag_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Rueckgabe" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="KKOfflineBezahlung_Type">
-		<sequence>
-			<element name="Kartenherausgeber" type="husst:BezahlArt_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="KartenNr" type="string" maxOccurs="1" minOccurs="1"/>
-			<element name="Pruefkennung" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="GueltigBis" type="gYearMonth" maxOccurs="1" minOccurs="1"/>
-			<element name="Unterschrift" type="boolean" maxOccurs="1" minOccurs="1"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Transaktionsort_Type">
-		<sequence>
-			<element name="Ortspunkt" type="husst:Ortspunkt_Type" maxOccurs="1" minOccurs="0"/>
-
-
-			<element name="Tarifpunkt" type="husst:Tarifpunkt_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="ID_Relcode" type="int" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Dieser Inhalt referenziert den Relationscode des Tarifs</documentation>
-				</annotation>
-			</element>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-
-		</sequence>
-		<attribute name="DatenversionInhalt" type="string" use="required">
-			<annotation>
-				<documentation>Der Inhalt von "DatenversionInhalt" der Tabelle VersionInhalt der Versorgung</documentation>
-			</annotation>
-		</attribute>
-		<attribute name="DatenversionZeitraum" type="string" use="required">
-			<annotation>
-				<documentation>Als DatenversionZeitraum wird das Feld "DatenversionZeitraum" des zum Verkaufszeitpunkt gültigen Zeitraum-Eintrages mit der höchsten SubZeitraumNr geliefert.</documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-	<complexType name="Restgeldbeleg_Type">
-		<sequence>
-			<element name="Ausgabevertriebsstelle" type="husst:Vertriebsstelle_Type" maxOccurs="1" minOccurs="1"/>
-
-			<element name="Kennung" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Eine eindeutige Kennung zur Identifikation des Restgeldbelegs.</documentation>
-				</annotation>
-			</element>
-			<element name="Beleg" type="husst:Beleg_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Ausstelldatum" type="dateTime" maxOccurs="1" minOccurs="0"/>
-
-		</sequence>
-	</complexType>
-
-	<complexType name="Schichtenliste_Type">
-		<sequence>
-			<element name="Version" type="husst:VersionStruktur_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Schicht" type="husst:Schicht_Type" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Datensatz_Type">
-		<choice>
-			<element name="Schichtbeginn" type="husst:Schichtbeginn_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Schichtabschluss" type="husst:Schichtabschluss_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Pruefbeginn" type="husst:Pruefbeginn_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Pruefabschluss" type="husst:Pruefabschluss_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Komponentenliste" type="husst:Komponentenliste_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Meldung" type="husst:Meldung_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Ausgabeabschnitt" type="husst:Ausgabeabschnitt_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Transaktionsdaten" type="husst:Transaktionsdaten_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Fahrtverlauf" type="husst:Fahrtverlauf_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Dienstbeginn" type="husst:Dienstbeginn_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Dienstende" type="husst:Dienstende_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Kontrolldaten" type="husst:Kontrolldaten_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Geldbehaelterliste" type="husst:Geldbehaelterliste_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Warenkorb" type="husst:Warenkorb_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="EBEErfassung" type="husst:EBEErfassung_Type" maxOccurs="1" minOccurs="1"/>
-		</choice>
-		<attribute name="Zeitpunkt" type="dateTime" use="required">
-			<annotation>
-				<documentation>Der jeweilge Zeitpunkt der Generierung des
-					Datenatzes.
-				</documentation>
-			</annotation>
-		</attribute>
-		<attribute name="DsNr" type="int" use="required">
-			<annotation>
-				<documentation>Eine fortlaufende ununterbrochene Nummer innerhalb
-					der Schicht. Die '0' sollte ausgenommen werden.
-				</documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-	<simpleType name="Meldungsklasse_Type">
-		<union memberTypes="husst:MeldungsklasseHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="MeldungsklasseHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Debug"/>
-			<enumeration value="husst.Info"/>
-			<enumeration value="husst.Warnung"/>
-			<enumeration value="husst.Fehler"/>
-			<enumeration value="husst.SchwererFehler"/>
-		</restriction>
-	</simpleType>
-
-	<simpleType name="Transaktionsart_Type">
-		<union memberTypes="husst:TransaktionsartHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="TransaktionsartHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.KA"/>
-			<enumeration value="husst.Geldkarte"/>
-			<enumeration value="husst.BOB"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="Any_Type">
-		<choice>
-			<element name="StringData" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="BinaryData" type="base64Binary" maxOccurs="1" minOccurs="0"/>
-		</choice>
-	</complexType>
-
-
-
-	<simpleType name="VorgangsTyp_Type">
-		<union memberTypes="husst:VorgangsTypHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="VorgangsTypHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.KeinFS"/>
-			<enumeration value="husst.UngueltigerFS"/>
-			<enumeration value="husst.TeilungueltigerFS"/>
-			<enumeration value="husst.Betrugsversuch"/>
-			<enumeration value="husst.Alkohol"/>
-			<enumeration value="husst.Rauchen"/>
-			<enumeration value="husst.Sachbeschaedigung"/>
-			<enumeration value="husst.Verhalten"/>
-			<enumeration value="husst.Notbremse"/>
-			<enumeration value="husst.Sonstiges"/>
-		</restriction>
-	</simpleType>
-
-	<simpleType name="VerfolgungsTyp_Type">
-		<union memberTypes="husst:VerfolgungsTypHUSST_Type husst:Projektspezifisch_Type"/>
-	</simpleType>
-
-	<simpleType name="VerfolgungsTypHUSST_Type">
-		<restriction base="string">
-			<enumeration value="husst.Polizei"/>
-			<enumeration value="husst.Anonym"/>
-			<enumeration value="husst.AnnahmeVerweigert"/>
-			<enumeration value="husst.VerkaufsDefekt"/>
-			<enumeration value="husst.Umsteiger"/>
-			<enumeration value="husst.Nacherfassung"/>
-			<enumeration value="husst.Loeschung"/>
-			<enumeration value="husst.Kulanz"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="Ueberweisung_Type">
-		<sequence>
-			<element name="BLZ-BIC" type="string" maxOccurs="1" minOccurs="1"/>
-			<element name="Konto-IBAN" type="string" maxOccurs="1" minOccurs="1"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Tarifpunkt_Type">
-		<sequence>
-			<element name="ID_Tarifpunkt" type="int" maxOccurs="1" minOccurs="0"/>
-			<element name="ID_Tarifgebiet" type="int" maxOccurs="1" minOccurs="1"/>
-			<element name="ReferenzExtern" type="string" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Wertbehaelter_Type">
-		<annotation>
-			<documentation>Hiermit werden Wertbehälter erfasst, z.B. Safebags.
-				Die Nummer enstpricht der Nummer des Wertbehälters, die Wertanzahl
-				der Anzahl der werthaltigen Anteile, z.B. die Anzahl der Belege.
-
-				Es
-				werden 2 Behälter unterschieden: 1. Behälter mit Bargeld -> dann
-				muss der Betrag ausgefüllt sein (früher Wert), 2. Behälter mit
-				werthaltigen Belegen -> dann muss die Wertanzahl ausgefüllt sein. 3.
-				Eine Mischform ist auch möglich.
-
-			</documentation>
-		</annotation>
-		<sequence>
-			<element name="WertAnzahl" type="int" maxOccurs="1" minOccurs="0"/>
-			<element name="Betrag" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="Kennung" type="string" use="required"/>
-	</complexType>
-
-	<complexType name="Person_Type">
-		<sequence>
-			<element name="Vorname" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Nachname" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Namenszuatz" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="StrasseHausNr" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Postleitzahl" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Laenderkennzeichen" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Wohnort" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Staat" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Geschlecht" maxOccurs="1" minOccurs="0">
-				<simpleType>
-					<restriction base="string">
-						<enumeration value="weiblich"/>
-						<enumeration value="maennlich"/>
-					</restriction>
-				</simpleType>
-			</element>
-			<element name="TelefonNr" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Geburtsdatum" type="dateTime" maxOccurs="1" minOccurs="0"/>
-			<element name="Staatsangehoerigkeit" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Legitimtation" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Beschreibung der legitimation, Ausweis,
-						EC-Karte, etc.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="LegitimationNr" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Ausweisnummer</documentation>
-				</annotation>
-			</element>
-			<element name="LegitimationsDatum" type="dateTime" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Ausstellungsdateum der Legitimation
-
-					</documentation>
-				</annotation>
-			</element>
-			<element name="LegimitationsLand" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Ausstellungsland der Legitimation
-					</documentation>
-				</annotation>
-			</element>
-			<element name="LegitimationBild" type="boolean" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>
-						Auf der Legitimation war ein Lichtbild, das
-						Lichtbild wurde dem EBE-Fall zugeordnet
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="VersionStruktur_Type">
-		<annotation>
-			<documentation>Hier müssen Hinweise zur Version des Schemas angegeben
-				werden.</documentation>
-		</annotation>
-		<sequence>
-			<element name="VersionMajor" type="int" maxOccurs="1" minOccurs="1" default="3">
-				<annotation>
-					<documentation>Diese Versionsnummer muss sich immer bei
-						Inkompatibilitäten zur Vorgängerversion ändern.</documentation>
-				</annotation>
-			</element>
-			<element name="VersionMinor" type="int" maxOccurs="1" minOccurs="1" default="0">
-				<annotation>
-					<documentation>Diese Versionsnummer zählt kompatible Anpassungen.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Aenderungsdatum" type="date" maxOccurs="1" minOccurs="1" default="2019-05-10"/>
-			<element name="Aenderungsautor" type="string" maxOccurs="1" minOccurs="1" default="Klaus Hitschler (krauth technology)"/>
-		</sequence>
-	</complexType>
-
-	<simpleType name="Codierung_Type">
-		<annotation>
-			<documentation>
-				Die Codierung entspricht der DB-Codierung
-			</documentation>
-		</annotation>
-		<restriction base="string">
-			<pattern value="[1-9a-zA-Z]{2}"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="KAReferenz_Type">
-		<sequence>
-			<element name="SamNummer" type="husst:INT3" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>SAM_ID.samNummer 24 Bit (Beispiel 0x654321), eine, im
-						gesamten Geltungsbereich der Kernapplikation eindeutige
-						SAM-Kartennummer</documentation>
-				</annotation>
-			</element>
-			<element name="SamSequenznummer" type="husst:INT4" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						samSequenznummer 32 Bit (Beispiel 0x789ABCDE),
-						eindeutige, fortlaufende Nummer die von einer
-						SAM-Karte generiert wird.
-					</documentation>
-				</annotation>
-			</element>
-		</sequence>
-	</complexType>
-
-
-	<complexType name="Polizei_Type">
-		<sequence>
-			<element name="Dienstnummer" type="string" maxOccurs="1" minOccurs="1"/>
-			<element name="Vorname" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Nachname" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="Dienststelle" type="string" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<complexType name="Mitnahme_Type">
-		<sequence>
-			<element name="Fahrgasttyp" type="husst:KundenTyp_Type" maxOccurs="1" minOccurs="1"/>
-			<element name="Anzahl" type="int" maxOccurs="1" minOccurs="1"/>
-		</sequence>
-	</complexType>
-
-	<simpleType name="ProjektspezifischAnstattKa_Type">
-		<annotation>
-			<documentation>
-				Definiert einen Typ, der anstatt eines Wertes aus der KA-Enumeration genutzt werden kann.
-				Die KA-Enumerationen definieren Werte zwischen 1 und 255 (INT1). Wenn Buchstaben vorkommen, ist es ein Projektspezifischer Wert.
-			</documentation>
-		</annotation>
-		<restriction base="string">
-			<pattern value="[A-Za-z][A-Za-z0-9_]*"/>
-		</restriction>
-	</simpleType>
-
-	<complexType name="KundenTyp_Type">
-		<simpleContent>
-			<extension base="husst:KundenTypSimple_Type">
-				<attribute name="Bezeichnung" type="string" use="optional">
-					<annotation>
-						<documentation>
-							Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
-						</documentation>
-					</annotation>
-				</attribute>
-			</extension>
-		</simpleContent>
-	</complexType>
-
-	<simpleType name="KundenTypSimple_Type">
-		<union memberTypes="husst:KundenTypKa_Type husst:ProjektspezifischAnstattKa_Type"/>
-	</simpleType>
-
-	<simpleType name="KundenTypKa_Type">
-		<annotation>
-			<documentation>
-        Der Kundentyp kommt aus der VDV-KA.
-        Die KA-Werte kommen aus dem EN1545: ProfileCodeIOP
-			</documentation>
-		</annotation>
-		<restriction base="husst:INT1">
-			<enumeration value="0">
-				<annotation>
-					<documentation>nicht spezifiziert/unbestimmt</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="1">
-				<annotation>
-					<documentation>Erwachsener</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="2">
-				<annotation>
-					<documentation>Kind</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="3">
-				<annotation>
-					<documentation>Student</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="5">
-				<annotation>
-					<documentation>Behinderter</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="6">
-				<annotation>
-					<documentation>Sehbehinderter</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="7">
-				<annotation>
-					<documentation>Hoergeschaedigter</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="8">
-				<annotation>
-					<documentation>Arbeitsloser/Sozialhilfeempfaenger</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="9">
-				<annotation>
-					<documentation>Personal</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="10">
-				<annotation>
-					<documentation>Militaeranhehoeriger</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="19">
-				<annotation>
-					<documentation>Schueler</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="20">
-				<annotation>
-					<documentation>Azubi</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="25">
-				<annotation>
-					<documentation>Senior</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="64">
-				<annotation>
-					<documentation>ermäßigt</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="65">
-				<annotation>
-					<documentation>Fahrrad</documentation>
-				</annotation>
-			</enumeration>
-			<enumeration value="66">
-				<annotation>
-					<documentation>Hund</documentation>
-				</annotation>
-			</enumeration>
-		</restriction>
-	</simpleType>
-
-	<complexType name="Teilrelation_Type">
-		<sequence>
-			<element name="SortOrder" type="int" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>
-						Die Sortierungsreihenfolge wird benötigt, um die
-						Richtung der Durchfahrt zu erhalten.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="ID_Preisstufe" type="husst:INT4" maxOccurs="1" minOccurs="1"/>
-			<element name="ReferenzExternPreisstufe" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="ID_Tarifgebiet" type="husst:INT4" maxOccurs="1" minOccurs="1"/>
-
-			<element name="Start" type="husst:Tarifpunkt_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="Ziel" type="husst:Tarifpunkt_Type" maxOccurs="1" minOccurs="0"/>
-			<element name="ReferenzExternRelation" type="string" maxOccurs="1" minOccurs="0"/>
-			<element name="ID_Preisquelle" type="int" maxOccurs="1" minOccurs="0"/>
-			<element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-		<attribute name="DatenversionInhalt" type="string" use="required">
-			<annotation>
-				<documentation>Der Inhalt von "DatenversionInhalt" der Tabelle VersionInhalt der Versorgung</documentation>
-			</annotation>
-		</attribute>
-		<attribute name="DatenversionZeitraum" type="string" use="required">
-			<annotation>
-				<documentation>Als DatenversionZeitraum wird das Feld "DatenversionZeitraum" des zum Verkaufszeitpunkt gültigen Zeitraum-Eintrages mit der höchsten SubZeitraumNr geliefert.</documentation>
-			</annotation>
-		</attribute>
-	</complexType>
-
-	<complexType name="Rechnungsstellung_Type">
-		<annotation>
-			<documentation>Dieses Element trägt nähere Angaben zum nachfolgenden Rechnungsstellungs- oder verfolgungsprozess.</documentation>
-		</annotation>
-		<sequence>
-			<element name="RechnungsRef" type="string" maxOccurs="1" minOccurs="1">
-				<annotation>
-					<documentation>In der Regel eine Rechnungsnummer oder eine generierte Referenz auf eine zu erstellende Rechnung.
-					</documentation>
-				</annotation>
-			</element>
-			<element name="KundenRef" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Eine Referenz auf den Kunden zur Rechnungsstellung, in der Regel eine Kundennummer
-					</documentation>
-				</annotation>
-			</element>
-			<element name="Vorgangszeitpunkt" type="dateTime" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Der zum Verkaufszeitpunkt zugehörige Zeitstempel.</documentation>
-				</annotation>
-			</element>
-			<element name="VorgangsRef" type="string" maxOccurs="1" minOccurs="0">
-				<annotation>
-					<documentation>Ein optionaler Bezug auf den dazugehörigen Verkaufsvorgang.</documentation>
-				</annotation>
-			</element>
-		</sequence>
-	</complexType>
-
-	<complexType name="Ortspunkt_Type">
-		<sequence>
-			<element name="ID_Ortspunkt" type="int" maxOccurs="1" minOccurs="0"/>
-			<element name="ReferenzExtern" type="string" maxOccurs="1" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-	<simpleType name="DateTimeCompact">
-		<restriction base="dateTime">
-			<minInclusive value="1990-01-01T00:00:00Z" />
-			<maxInclusive value="2117-12-31T23:59:58Z" />
-		</restriction>
-	</simpleType>
-	<simpleType name="DateCompact">
-		<restriction base="date">
-			<minInclusive value="1990-01-01" />
-			<maxInclusive value="2117-12-31" />
-		</restriction>
-	</simpleType>
-	<simpleType name="Betriebszeit_Type">
-		<annotation>
-			<documentation>Betriebszeiten dürfen über 24:00 Uhr hinausgehen
-			</documentation>
-		</annotation>
-		<restriction base="string">
-			<pattern value="[0-9]{1,2}:[0-9]{1,2}" />
-		</restriction>
-	</simpleType>
-	<simpleType name="INT1">
-		<restriction base="unsignedInt">
-			<minInclusive value="0" />
-			<maxInclusive value="255" />
-		</restriction>
-	</simpleType>
-	<simpleType name="INT2">
-		<restriction base="unsignedInt">
-			<minInclusive value="0" />
-			<maxInclusive value="65535" />
-		</restriction>
-	</simpleType>
-	<simpleType name="INT3">
-		<restriction base="unsignedInt">
-			<minInclusive value="0" />
-			<maxInclusive value="16777215" />
-		</restriction>
-	</simpleType>
-	<simpleType name="INT4">
-		<restriction base="unsignedInt">
-			<minInclusive value="0" />
-			<maxInclusive value="4294967295" />
-		</restriction>
-	</simpleType>
-	<simpleType name="INT8">
-		<restriction base="unsignedLong">
-			<minInclusive value="0" />
-			<maxInclusive value="18446744073709551615" />
-		</restriction>
-	</simpleType>
-	<simpleType name="FLOAT1">
-		<annotation>
-			<documentation>englische Notation beachten, z. B. 19 Euro =
-				19.00
-				Euro
-			</documentation>
-		</annotation>
-		<restriction base="decimal">
-			<minInclusive value="0" />
-			<maxInclusive value="100" />
-		</restriction>
-	</simpleType>
-	<simpleType name="KoordWgs84_Type">
-		<restriction base="float"/>
-	</simpleType>
-	<simpleType name="Char">
-		<restriction base="string">
-			<minLength value="1" />
-			<maxLength value="1" />
-		</restriction>
-	</simpleType>
-	<simpleType name="blobString">
-		<restriction base="string">
-			<pattern value="[ -þ€–]*" />
-		</restriction>
-	</simpleType>
-
-
-
-	<complexType name="DynAttribut_Subtype">
-		<annotation>
-			<documentation>
-				Der Subtyp DynAttribut_Subtype dient der Definition von
-				dynamischen Attributen als mögliche Erweiterung für die
-				Xml-Darstellung der Daten. Der Subtyp wird nicht 1:1 für
-				eine Abbildung auf ein relationales Datenbankmodell
-				verwendet.
-			</documentation>
-		</annotation>
-		<sequence>
-			<element name="Name" type="string" maxOccurs="1" minOccurs="1"/>
-			<element name="Wert" type="string" maxOccurs="unbounded" minOccurs="0"/>
-		</sequence>
-	</complexType>
-
-
+      </documentation>
+    </annotation>
+    <restriction base="husst:INT1">
+      <enumeration value="0">
+        <annotation>
+          <documentation>nicht spezifiziert/unbestimmt</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="1">
+        <annotation>
+          <documentation>Linienbus im Stadtverkehr</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="3">
+        <annotation>
+          <documentation>Metro/U-Bahn/S-Bahn</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="4">
+        <annotation>
+          <documentation>Strassenbahn/TRAM</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="6">
+        <annotation>
+          <documentation>Schiff</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="10">
+        <annotation>
+          <documentation>ICE</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="11">
+        <annotation>
+          <documentation>Überlandbus/Regionalbus</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="19">
+        <annotation>
+          <documentation>Regionalzug</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="20">
+        <annotation>
+          <documentation>IC</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="21">
+        <annotation>
+          <documentation>Standseilbahn</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="29">
+        <annotation>
+          <documentation>Regionalexpress</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="30">
+        <annotation>
+          <documentation>Expressbus</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="31">
+        <annotation>
+          <documentation>Flughafenzubringer</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="32">
+        <annotation>
+          <documentation>Verbundnahverkehr</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="33">
+        <annotation>
+          <documentation>Verbundnahverkehr ohne Kurzstrecke</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="34">
+        <annotation>
+          <documentation>SPNV</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="35">
+        <annotation>
+          <documentation>Verbundnahverkehr ohne Sonderverkehrsmittel</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="36">
+        <annotation>
+          <documentation>Fähre</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="37">
+        <annotation>
+          <documentation>Bergbahn</documentation>
+        </annotation>
+      </enumeration>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="VerfolgungsTyp_Type">
+    <union memberTypes="husst:VerfolgungsTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="VerfolgungsTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Polizei"/>
+      <enumeration value="husst.Anonym"/>
+      <enumeration value="husst.AnnahmeVerweigert"/>
+      <enumeration value="husst.VerkaufsDefekt"/>
+      <enumeration value="husst.Umsteiger"/>
+      <enumeration value="husst.Nacherfassung"/>
+      <enumeration value="husst.Loeschung"/>
+      <enumeration value="husst.Kulanz"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="VorgangsTyp_Type">
+    <union memberTypes="husst:VorgangsTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="VorgangsTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.KeinFS"/>
+      <enumeration value="husst.UngueltigerFS"/>
+      <enumeration value="husst.TeilungueltigerFS"/>
+      <enumeration value="husst.Betrugsversuch"/>
+      <enumeration value="husst.Alkohol"/>
+      <enumeration value="husst.Rauchen"/>
+      <enumeration value="husst.Sachbeschaedigung"/>
+      <enumeration value="husst.Verhalten"/>
+      <enumeration value="husst.Notbremse"/>
+      <enumeration value="husst.Sonstiges"/>
+    </restriction>
+  </simpleType>
+
+  
+  <element name="Schichten" type="husst:Schichtenliste_Type"/>
 </schema>


### PR DESCRIPTION
Ich habe einmal alle Xsd-Elemente zuerst in drei Klassen eingeteilt (Komplexe Typen, Werttypen und Enumerationen) sortiert und diese Klassen jeweils alphabetisch sortiert.

Das Diff ist nicht zu empfehlen ;)