### PR TITLE
HUSST_Versorgungsdaten_2_46.xsd (in Arbeit) aufgesetzt

### DIFF
--- a/Versionen 1 und 2/HUSST_Versorgungsdaten_2_46.xsd
+++ b/Versionen 1 und 2/HUSST_Versorgungsdaten_2_46.xsd
@@ -1,0 +1,4724 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:tpd="http://husst.de/Tarifpersonaldaten-2_46"
+  targetNamespace="http://husst.de/Tarifpersonaldaten-2_46"
+  elementFormDefault="qualified"
+  attributeFormDefault="unqualified">
+	
+	<xs:annotation>
+		<xs:documentation>Tarifdatenversorgung von Verkaufssystemen
+
+            Änderungen:
+        in Arbeit: 2020-04-28 - V2.46 - hneubauer(kt)
+        stabil: 2019-09-17 - V2.45 - sgumbert(hQ)
+            NEU: Tarifpunktmengen_Type
+				 TarifpunktmengeElemente_Type
+				 ID_Tarifpunktmenge in RaeumlicheGueltigkeit_Type ergänzt
+				 Zeitraumoptionen_Type in Elementliste aufgenommen.
+        stabil: 2019-07-19 - V2.44 - sgumbert(hQ)
+            NEU: DynAttribut in Types ergänzt, die eindeutigen PrimeKey (ID (+ IDZeitraum)) haben
+                 um ID_Zeitraum und DynAttribut ergänzt:
+                 Sortenklassen_Type, GeraetEinsatztypen_Type, Geraetetypen_Type, IdentobjektTypen_Type, Identobjekt_Type, MwSt_Type,
+                 Ortspunkttypen_Type, Personal_Type, Preisspaltekennungen_Type, Relationscodegruppentypen_Type
+
+                 um DynAttribut ergänzt:
+                 Beauftragungen_Type, Bediengebiete_Type, Bundeslaender_Type, Kalender_Type, OTPTypen_Type, OrtspunkteKA_Type, OrtspunkteTG_Type,
+                 Ortspunkte_Type, Preisquellen_Type, Preisspalten_Type, PreisstufenDirektwahl_Type, Relationen_Type, TagesartMerkmalElemente_Type,
+                 Tagesarten_Type, TagesmerkmalElemente_Type, Tagesmerkmale_Type, Tarifarten_Type, Tarifgebiete_Type, TarifrelevantePunkte_Type,
+                 Unternehmen_Type, Vias_Type, Wege_Type, Zielanzeigetyp_Type
+
+                 um ID_Zeitraum (aber nicht um DynAttribut) ergänzt:
+                 Waehrungen_Type, Geraet_Type, Personaleinsatz_Type
+        stabil: 2019-03-27 - V2.43 - hneubauer(kt)
+            CHG: alle Datentypen ändern ihre Element-Organisation von xs:all zu xs:sequence außerdem definieren alle 
+                 Datentypen mit DynAttribut die Obergrenze des Elements statt "1" jetzt als "unbounded"          
+            NEU: PreisStufenbezeichnungKurz in Preise_Type
+            NEU: DynAttribut in Preise_Type und Sortengruppen_Type hinzugefügt.
+            CHG: alle fehlenden nillable und min/maxOccurs Attribute gesetzt
+        stabil: 2018-05-16 - V2.42 - hneubauer(kt)
+            NEU: ID_RaeumlGueltDS in RaeumlicheGueltigkeit_Type
+            CHG: PrimeKey jetzt ID_RaeumlGueltDS + ID_Zeitraum in RaeumlicheGueltigkeit_Type
+            CHG: bisheriger PrimeKey jetzt Idx_RaeumlGuelt_Main in RaeumlicheGueltigkeit_Type
+            NEU: ID_OrtspunktKADS in OrtspunkteKA_Type
+            CHG: PrimeKey jetzt ID_OrtspunktKADS + ID_Zeitraum in OrtspunkteKA_Type
+            CHG: bisheriger PrimeKey jetzt Idx_OPKA_Main in OrtspunkteKA_Type
+            NEU: ID_OrtspunktTGDS in OrtspunkteTG_Type
+            CHG: PrimeKey jetzt ID_OrtspunktTGDS + ID_Zeitraum in OrtspunkteTG_Type
+            CHG: bisheriger PrimeKey jetzt Idx_OPTG_Main in OrtspunkteTG_Type
+            NEU: ID_TarifrelevanterpunktDS in TarifrelevantePunkte_Type
+            CHG: PrimeKey jetzt ID_TarifrelevanterpunktDS + ID_Zeitraum in TarifrelevantePunkte_Type
+            CHG: bisheriger PrimeKey jetzt Idx_OTP_Main in TarifrelevantePunkte_Type
+            NEU: ID_OrtspunktDS in Ortspunkte_Type
+            CHG: PrimeKey jetzt ID_OrtspunktDS + ID_Zeitraum in Ortspunkte_Type
+            CHG: bisheriger PrimeKey jetzt Idx_OP_Main in Ortspunkte_Type
+            NEU: ID_PstDirektDS in PreisstufenDirektwahl_Type
+            CHG: PrimeKey jetzt ID_PstDirektDS + ID_Zeitraum in PreisstufenDirektwahl_Type
+            CHG: bisheriger PrimeKey jetzt Idx_PstDirekt_Main in PreisstufenDirektwahl_Type
+        stabil: 2018-02-12 - V2.41 - hneubauer(kt)
+            CHG: alle Stringrestriktionen aufgehoben:
+                 alle tpd:PrintableString / tpd:PrintableString80 mit ggf. weiteren Einschränkungen der Gesamtlänge
+                 zu xs:string geändert.
+            CHG: implizite Enumerationen explizit definiert      
+            NEU: ZuordnungRelCodeGrp_Type
+            NEU: ZusSorteAnbindung_Type
+            NEU: Tarifobjekttyp_Type            
+            CHG: Zusatzsorten_Type und TarifobjektTarifpunkte_Type verweisen auf die neuen expliziten Datentypen
+            CHG: SammelbelegType zu Sammelbeleg_Type normalisiert
+        stabil: 2017-11-17 - V2.40 - hneubauer(kt)
+            NEU: Tagesmerkmale_Type
+            NEU: Tagesmerkmalelemente_Type
+            NEU: Tagesartmerkmalelemente_Type
+            CHG: Sorten_Type.GueltigParam und Sorten_Type.GueltigParamEFS Syntax erweitern
+            ---  einwertige Primekey-Schlüssel für dynamische Attribute ergänzt in Sortengruppen_Type und Preise_Type 
+            NEU: ID_SortengruppeDS in Sortengruppen_Type 
+            CHG: PrimeKey jetzt ID_SortengruppeDS + ID_Zeitraum in Sortengruppen_Type 
+            CHG: bisheriger PrimeKey jetzt Idx_SoGr_Main in Sortengruppen_Type 
+            NEU: ID_PreisDS in Preise_Type 
+            CHG: PrimeKey jetzt ID_SortengruppeDS + ID_Zeitraum in in Preise_Type 
+            CHG: bisheriger PrimeKey jetzt Idx_Pr_Main in Preise_Type
+        in Arbeit: 2017-03-15 - V1.39 - hneubauer(kt)
+            NEW: Einbindung ktAppinfo als Namespace für kt-spezifische Definitionserweiterungen über xs:appinfo Einträge 
+            NEW: Element ID_TeilrelationDS bei TeilRelationen_Type hinzugefügt und Primekey umgebaut            
+            NEW: Element DynAttribut bei Sorte_Type und bei TeilRelationen_Type hinzugefügt            
+            NEW: Sprachtexte_Type und Lang_Type hinzugefügt
+            NEW: DynAttributDef_Type, DynAttributWert_Type und DynAttributTyp_Type hinzugefügt            
+            NEW: Ausgabeoption in Sorte_Type eingefügt
+            CHG: Bedeutung des Feldes Zahlart in Sorte_Type geändert
+            NEW: Ausgabeoption in Sorte_Type eingefügt
+        HUSST:2015-10-30 - V1.38 - husst-Arbeitstreffen(2015-10-07)/anschließende Abstimmungen 
+        stabil: 2016-06-15 - V1.37 - hneubauer(kt)
+            NEW: TO_ID_Sorte und Enumeration Tarifobjekttyp "Sorten" in TarifobjektTarifpunkte_Type
+            NEW: SortOrder in PreisStufen_Type
+            NEW: Deaktiviert und ID_Zeitraum in Kalender_Type (ID_Zeitraum auch im primekey)
+           +UPD: Druckoption in Sorten_Type um zwei Interpretationen ergänzt
+           +NEW: ViaDrucktext und ViaDrucktext_Rueck in Teilrelationen_Type
+            NEW: ID_PreisStufeReferenz in Preise_Type
+            NEW: Preisabschlussberechnung in Sorte_Type
+            NEW: neuer Performanceindex für Sortengruppen_Type: Idx_SoGr_ID_Sorte
+           +NEW: Updateinfo_Type hinzugefügt
+            CHG: Sammelbeleg erweitert um Option "auswahl" in Sorten_Type
+            NEW: ID_MwSt in Sorten_Type eingefügt
+            CHG: ID_TarifGebiet und ReferenzExtern in Tarifarten_Type eingefügt
+            CHG: SorteTarifgeber in Sorten_Type von String(30) zu String(80) geändert
+            NEW: ExtOrtsNummer in OrtspunkteTG_Type ergänzt
+            CHG: TarifgeberProduktNr in Preise_Type von INT4 zu String(80) geändert
+            NEW: ID_Start_TarifPunktTyp und ID_Ziel_TarifPunktTyp in Teilrelationen_Type
+           +NEW: TarifobjektTarifpunkte_Type
+        stabil: 2014-10-15 - V1.36 - hneubauer(kt)
+            NEW: ReferenzExtern in MwSt_Type
+            NEW: Zielanzeigetyp_Type
+            NEW: Deaktiviert und ID_Zeitraum in Fahrten_Type, Wege_Type,
+                 Wegpositionen_Type, Linie_Type aufgenommen, ID_Zeitraum auch in den Primekey
+            DEL: ZeitGruppeElement_Type gelöscht
+            NEW: Zielanzeigetext_Type
+            NEW: Wagenumlauf_Type
+            NEW: Wegpositionenzeit_Type
+            NEW: Innenanzeigetext bei Ortspunkte_Type
+            NEW: Fangbereich bei Wegpositionen_Type
+            NEW: ID_BetriebsTagesArt in Fahrten_Type aufgenommen - auch in den Primekey
+            CHG: ID_WegeNr in Wege_Type und Wegpositionen_Type umbenannt in ID_Weg entsprechend auch in Linie_Type
+            NEW: ID_OrtsPunktTypRef und ID_OrtsnummerRef in Ortspunkt_Type
+            NEW: BezeichnungDruck in Ortspunkt_Type
+            NEW: BezeichnungKurz in Ortspunkt_Type
+            NEW: OrtsbezeichnungDruck in OrtspunkteTG_Type
+            NEW: OrtsbezeichnungKurz in OrtspunkteTG_Type
+            NEW: TarifpunktbezeichnungDruck in OrtspunkteTG_Type
+            NEW: TarifpunktbezeichnungKurz in OrtspunkteTG_Type
+        2013-08-29 - V1.35 - hneubauer(kt)
+            NEW: Fangbereich in Ortspunkte_Type aufgenommen
+            NEW: Komfortklasse in TeilRelationen_Type aufgenommen
+            CHG: ID_Tarifart in PrimeKey TeilRelationen-Type aufgenommen
+            CHG: ID_Relation in ID_TeilRelation geändert in TeilRelationen_Type
+            NEW: ID_TeilRelation in Relationen_Type
+            CHG: Element ID_WegeNr_Rueck in Linien_Type darf fehlen
+        2012-10-17 - V1.34 - hneubauer(kt)
+            NEW: ID_PreisStufe in den primekey von Zusatzsorten_Type aufgenommen
+            DEL: ID_TarifGebiet aus dem Zusatzsorten_Type herausgenommen
+            CHG: Elementname primkey in primekey geändert
+            NEW: Status in VersionenStruktur_Type
+            NEW: VersionStatus_Type
+            CHG: XKoordWgs84/YKoordWgs84 in Ortspunkte_Type und KA_MwSt in TMwSt_Type
+                 optional gemacht
+            CHG: alle nillable="true" um minOccurs="0" maxOccurs="1" erweitert
+            DEL: eigener Boolean-Type zugunsten xs:boolean gelöscht
+            CHG: alle xs:sequence-Blöcke durch xs:all-Blöcke ersetzt
+            CHG: Doppeltes Deaktiviert in Bediengebiete_Type gelöscht
+            CHG: ID_Preisstufe in ID_PreisStufe geaendert in Zusatzsorten_Type
+            NEW: ID_Zeitraum in Tarifarten_Type
+            DEL: ID_Tarifart in Relationen_Type
+                 prepared if necessary: NEW: GebundeneAnzahl in Zusatzsorten_Type
+            NEW: primkey-Angabe in Zusatzsorten_Type
+        2012-09-25 - V1.33 - hneubauer(kt)
+            CHG: ID_RelCode in TarifrelevantePunkte_Type nillable="true" statt bisher
+                 "false"
+            NEW: Zusatzsorten_Type
+            NEW: ID_Sortengruppe und ID_SortenGruppenTyp in TarifrelevantePunkte_Type
+            NEW: ID_PreisStufe in Sortengruppen_Type (optional)
+            NEW: Deaktiviert für alle Datentypen, mit Element ID_Zeitraum (außer
+            Zeitraeume_Type)
+            NEW: RelationsIDTarifgeber in TeilRelationen_Type
+            NEW: SubZeitraumNr in Zeitraueme_Type
+            CHG: ID_HauptZeitraum zu HauptZeitraumNr in Zeitraeume_Type geändert
+            NEW: Attribut Zusatzsorte (Boolean) in Sorten_Type
+        2012-09-10 - V1.32a - cfiedler(kt)
+            CHG: Indexname bei PersonalIdentobejekte, Identobjekte
+            2012-08-15 - V1.32 - hneubauer(kt)
+            CHG: ID_HauptZeitraum in Zeitraeume_Type darf fehlen
+            CHG: ID_AbrUnternehmen in Personal_Type darf fehlen
+            CHG: Aenderungsdatum und Aenderungsautor in Versions_Type dürfen fehlen
+            CHG: INT4 maxInclusive value="4294967295" korrigiert (war "31")
+            NEW: IdentObjektTypen_Type
+            NEW: IdentObjekte_Type
+            NEW: PersonalIdentObjekte_Type
+        2012-07-18 - V1.31 - hneubauer(kt)
+            NEW: zusätzliche Textfelder für die Sorten_Typen:
+                 AnzeigeKurz/-Lang
+                 KundendisplayKurz/-Lang
+                 BelegdruckKurz/Lang
+                 Mindespersonenanzahl
+                 Hoechstpersonenanzahl
+            NEW: ID_Tarifkennung in Zeitraeume_Type
+        2012-05-14 - V1.30 - hneubauer(kt)
+            NEW: Zeitraeume_Type - ID_HauptZeitraum - optional
+            NEW: ZeitraumOptionen_Type
+            CHG: ID_TarifGebiet aus primkey des Sorten_Type entfernt - ID_Sorte ist
+                 eindeutig innerhalb des ID_Zeitraum
+            NEW: SortenTarifarten_Type - n:m Beziehung zwischen Sorten und Tarifarten
+            NEW: Sorten_Type - Druckoption
+            NEW: Sorten_Type - KdNummer
+            DEL: Sorten_Type - ID_Tarifart
+        2012-02-29 - V1.29 - hneubauer(kt)
+            NEW: ID_Bediengebiet in Sortengruppen_Type aufgenommen - auch in den
+                 Schlüssel
+            NEW: ID_OTPTyp_Ref und Bezeichnung_Ref in TarifrelevantePunkte_Type
+                 aufgenommen
+            NEW: Rang in TarifrelevantePunkte_Type aufgenommen
+            CHG: ID_RelCode kann jetzt auch NILL sein in TarifrelevantePunkte_Type
+        2012-02-23 - V1.28a - hneubauer(kt)
+            CHG: Sorten_Type - Zahlungsart - im Kommentar den Wertebereich und seine
+                 Bedeutung definiert
+        2012-01-24 - V1.28 - hneubauer(kt)
+            NEW: Standortwahl_ID_Bediengebiet in TarifrelevantePunkte_Type ergänzt
+        2012-01-04 - V1.27 - hneubauer(kt)
+            NEW: PreisuebergangVorverkauf in Sorten_Type aufgenommen
+            CHG: Tarifpunkte_Type Drucktext von 20 auf 50 Zeichen verlängert
+        2011-11-30 - V1.26 - hneubauer(kt)
+            CHG: Nachbarhaltestellen_Type ergänzt um SortOrder und ID_ViaNr
+        2011-09-30 - V1.25 - hneubauer(kt)
+            NEW: ID_Zeitraum in Nachbarhaltestellen_Type aufgenommen (auch in die
+                 Indexe)
+        2011-09-21 - V1.24 - hneubauer(kt)
+            CHG: Interpretationen_Type - Feld ID_Zeitraum ergänzt und Schlüssel
+                 korrigiert
+        2011-09-15 - V1.23 - hneubauer(kt)
+            NEW: Interpretationen_Type
+            NEW: OrtspunkteTG_Type
+        2011-08-24 - V1.22 - hneubauer(kt)
+            NEW: KA_Tarifpunktbezeichnung in OrtspunkteKA_Type
+            CHG: ID_TarifArt in Teilrealtionen_Type auf nillable="false" gesetzt
+        2011-08-12 - V1.21 - hneubauer(kt)
+            NEW: Nachbarhaltestellen_Type komplett überarbeitet
+            NEW: Bearbeitung_Type
+            NEW: Unternehmen_Type
+            NEW: Element GegenrichtungLiegtVor in Relationen_Type
+            NEW: Element ID_Unternehmen und ID_AbrUnternehmen in Personal_Type
+                 ergänzt
+            NEW: Element Gemeindekennziffer in Ortspunkte_Type ergänzt
+        2011-06-10 -
+            V1.20 - hneubauer(kt)
+            CHG: Schreibweise Element KA_ProdOrgID in Sorten_Type vereinheitlicht
+            CHG: Schreibweise Element TarifGebiet in
+                 VerkaufbareTarifgebiete_Type vereinheitlicht
+            CHG: Schreibweise Element Drucktext in Tarifpunkte_Type vereinheitlicht
+            CHG: Schreibweise Element Sortenklasse in Sortenklassen_Type
+                 vereinheitlicht
+            CHG: Schreibweise Element Layout in Preise_Type vereinheitlicht
+            CHG: Schreibweise Element ID_PreisStufe in RaeumlicheGueltigkeit_Type
+                 vereinheitlicht
+            NEW: Elemente ID_Tarifart in TeilRelationen_Type ergänzt
+            NEW: Elemente ID_TarifpunktTyp, ID_TarifPunktTypRef und ID_TarifPunktRef
+                 in Tarifpunkte ergänzt
+            NEW: Elemente ID_Tarifart in TeilRelationen_Type ergänzt
+        2011-05-31 - V1.19 - hneubauer(kt)
+            NEW: Elemente Anzeigetetxt und Drucktext bei PreisstufenDirektwahl_Type
+                 ergänzt
+        2011-05-27 - V1.18 - hneubauer(kt)
+            DEL: Element KA_psOrgID aus Preisstufen_Type entfernt
+            CHG: Element KA_PV umbenannt in KA_ProdOrgID in Preise_Type
+            DEL: Element KA_KVP aus Preise_Type entfernt
+            DEL: Element KA_OrtTypArt aus OrtspunkteKA_Type entfernt
+            DEL: Elemente KA_OrtOrgID, KA_Ort_Typ und KA_OrtNummer aus Sorten_Type
+                 entfernt
+            NEW: Element UpgradeStopp in Preisstufen_Type integriert
+            NEW: Elemente ID_OrtsPunktTyp und ID_OrtsNummer in
+                 TarifrelevantePunkte_Type ergänzt
+            CHG: Start_TarifPunktName und Ziel_TarifPunktName auf 80 Zeichen
+                 verlängert
+            NEW: Element AlternativePreisGruppe in Teilrelationen_Type
+            NEW: Element EinnahmeAufteilung in Teilrelationen_Type
+        2011-05-13 - V1.17 - hneubauer(kt)
+            NEW: PreisstufenDirektwahl_Type
+            NEW: ID_Schluesselwert als optionales Feld in Preisstufe_Type aufgenommen
+            CHG: Erstellungsdatum und Lieferant in Inhalt_Type auf
+                 "nillable="false" gesetzt und
+                 in den Primekey aufgenommen
+            CHG: ID_Bundesland in Ortspunkte_Type und TarifrelevantePunkte_Type auf
+                 nillable=true geändert
+            CHG: AttributText in den Primkey von Sortenattributgruppen_Type
+                 aufgenommen
+            CHG: Preise_Type Gueltigtext bisher 30 Zeichen, neu 60 Zeichen
+            CHG: Vias_Type, Anzeigetext bisher 80, neu 120 Zeichen
+            CHG: Vias_Type, Anzeigetextrueck, bisher 80, neue 120 Zeichen
+        2011-04-15 - V1.16 - hneubauer(kt)
+            NEW: Element/Type OrtspunkteKA_Type
+            CHG: Ortspunkte_Type - ID_Zeitraum ergänzt und auch in den Primary Key
+                 aufgenommen
+            CHG: Ortspunkte_Type - KA Elemente ausgelagert in OrtspunkteKA_Type
+        2011-02-21 - V1.15 - hneubauer(kt)
+            NEW: Element/Type RaeumlicheGueltigkeit_Type
+        2011-02-17 - V1.14a - hneubauer(kt)
+            CHG: Bei Sorten_Typ den Primkey um ID_TarifGebiet ergänzt
+        2011-02-17 - V1.14 - hneubauer(kt)
+            CHG: Element ID_Bundeslaender überall auf ID_Bundesland geändert
+            NEW: Element ID_Bundesland in Ortspunkte_Typ und in
+                 TarifrelevantePunkte_Typ aufgenommen
+        2011-02-16 - V1.13a - hneubauer(kt)
+            CHG: Sortengruppen_Type - Primekey korrigiert
+                 TarifrelevantePunkte_Type - Primekey korrigiert
+        2011-02-16 - V1.13 - hneubauer(kt)
+            NEW: Attribut Vertriebsweg bei Relationen_Typ
+            2011-02-15 - V1.12b - hneubauer(kt)
+            NEW: Den meisten Typen wurde eine Primekey Definition
+                 manchen noch weitere Index Definitionen in einem
+                 "appinfo" Tag mitgegeben.            
+                 Wird intern bei krauth technology verwendet.
+            CHG: Elemente in OePVTarifDB wurden neu sortiert
+        2011-02-11 - V1.12a - hneubauer(kt)
+            NEW: Sortenattribut KA Infotext
+            NEW: Element/Type Bundeslaender
+            NEW: Element/Type Feiertage
+            NEW: Element/Type Preisquellen
+            NEW: Attribut ID_Preisquelle bei TeilRelationen_Type
+            NEW: optionales Attribut ID_TarifGebiet bei Fahrten_Type
+            NEW: Attribut KA_MwSt bei MwSt_Type
+            NEW: Attribut KA_RaeumlicheCodierung bei Preise_Type
+            NEW: Attribut KA_Rabatttyp bei Preise_Type
+            NEW: Attribut KA_Mitnahme bei Sorten_Type
+            NEW: Attribut KA_Verkehrsmittel bei Sorten_Type
+            NEW: Attribut KA_Serviceklasse bei Sorten_Type
+        2010-12-16 - V1.11 - hneubauer(kt)
+            DEL: optionales Attribut SpezialFlag bei Sorten_Type entfernt
+            DEL: optionale Fahrzeit und Haltezeit Elemente in Wegpositionen entfernt
+        2010-12-03 - V1.10 - hneubauer(kt)
+            CHG: Max-Länge des Basistyps PrintableString auf 256 erhöht
+            NEW: Element/Type Sortenattributgruppen und dazu ID_SoAttributKlasse_Type
+            NEW: Attribut optional SpezialFlag bei Sorten_Type und
+                 SpezialFlag_Type
+            NEW: Attribut optional PstLayoutTyp bei Preisstufen_Type
+            NEW: Attribut BezeichnungKurz bei Preisspalten_Type ergänzt
+            NEW: optionales Attribut ID_Weg in Fahrten_Type ergänzt
+            NEW: in Fahrten_Type optional Fahrzeitgruppe und Haltezeitgruppe ergänzt
+            NEW: in Fahrten_Type optional Abfahrt eingefügt
+            NEW: KoordWgs84_Type
+            NEW: Betriebszeit_Type
+            NEW: zwei optionale Attribute XKoordWgs84 und YKoordWgs84 bei
+                 Ortpunkte_type
+            NEW: bei Wegpositionen: Entfernung, Fahrzeit und Haltezeit ergänzt
+        2010-11-24 - V1.9 - hneubauer(kt)
+            CHG: Referenz auf Element Inhalt in die Gesamtliste aufgenommen
+            CHG: Schreibweise "ID_OrtsPunktTyp" bei "Ortspunkttypen_Type" korrigiert
+        2010-11-19 - V1.8 - hneubauer(kt)
+            DEL: Attribute Gueltig_param und Gueltig_text aus Preisstufen_type
+                 entfernt
+            CHG: Attribute Drucktext1 bis Drucktext3 auf 250 Zeichen in Sorten_Type
+                 erhöht
+            CHG: Neu: Datentyp Inhalt_Type
+        2010-11-11 - V1.7 - sgumbert(highQ)
+            CHG: Richtung_Type -&gt; Richtungen_Type
+        2010-10-29 - V1.6 - hneubauer(kt)
+            CHG: Element GueltigRegel in Preise_Type ergänzt
+        2010-10-27 - V1.5 - hneubauer(kt)
+            CHG: Personal_Type.Passwort - Maxlänge von 10 auf 20 erhöht
+        2010-10-14 -V1.4 - hneubauer(kt)
+            CHG: Element TarifInfo in Sorten_Type wirklich eingbaut
+            CHG: Element TarifInfo in Sortengruppen_Type wirklich eingbaut
+            CHG: Element GueltigParam in Sorten_Type auf 250 erweitert
+            CHG: Element GueltigParam in Preisstufen_Type auf 250 erweitert
+            CHG: Element GueltigParam in Preise_Type auf 250 erweitert
+        2010-10-13 - V1.3 - sgumbert(highQ)
+            NEW: simpleType blobString
+            NEW: Element TarifInfo in Sorten_Type
+            NEW: Element TarifInfo in Sortengruppen_Type
+            CHG: Element GueltigMin(INT4) umbenannt zu
+            GueltigParam(PrintableString[20]) in Preisstufen_Type
+            CHG: Element GueltigText in Preisstufen_Type: PrintableString[20]-&gt;[30]
+            CHG: Element Layout in Sorten_Type: PrintableString -&gt; blobString
+            CHG: Element GueltigkeitsRegel umbenannt in GueltigRegel in
+                 Sorten_Type
+            CHG: Element GueltigkeitsDauer(INT4) umbenannt in
+                 GueltigParam(PrintableString[20]) in Sorten_Type
+            NEW: Element GueltigText in Sorten_Type
+            CHG: Element GueltigkeitsEinheiten umbenannt in GueltigParam (INT4 -&gt;
+                 PrintableString[20]) in Preise_Type
+            DEL: Element GueltigkeitsRegel in Preise_Type
+            NEW: Element GueltigText in Preise_Type
+            CHG: Element KA_Referenz_EFS in Preise_Type: PrintableString -&gt; [50]
+            CHG: Element ID_Bediengebiet in TarifrelevantePunkte_Type:
+                 nillable="false" gesetzt
+            DEL: Element ID_Tarifgbebiet in Sortengruppen_Type
+        2010-10-08 - V1.2 - hneubauer(kt)
+            CHG: in den neuen Feldern wurden tlw. xs:... Typen verwendet, das ist
+            jetzt alles auf tns:... Typen umgestellt
+        2010-10-08 - V1.1 - hneubauer(kt)
+            NEW: Element -&gt; VersionStruktur:VersionStruktur_Type
+                 in den Default-Werten sind die Infos zum Stand der Strukturversion
+                 abzulegen
+            DEL: Element Sortenpakete und Typ Sortenpakete_Type
+            CHG: Element OTP umbenannt zu TarifrelevantePunkte
+            NEW: Element -&gt; Fahrten:Fahrten_Type
+            NEW: Typ -&gt; Richtung_Type
+            NEW: Element Rabattklass in Sorten_Type
+            NEW: Element Fahrgasttyp in Sorten_Type
+            NEW: Element LayoutBeleg in Sorten_Type
+            NEW: Element BelegAnzahl in Sorten_Type
+            NEW: Element Sammelbeleg in Sorten_Type
+        </xs:documentation>
+	</xs:annotation>
+
+	<xs:simpleType name="DateTimeCompact">
+		<xs:restriction base="xs:dateTime">
+			<xs:minInclusive value="1990-01-01T00:00:00Z"/>
+			<xs:maxInclusive value="2117-12-31T23:59:58Z"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="DateCompact">
+		<xs:restriction base="xs:date">
+			<xs:minInclusive value="1990-01-01"/>
+			<xs:maxInclusive value="2117-12-31"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Betriebszeit_Type">
+		<xs:annotation>
+			<xs:documentation>Betriebszeiten dürfen über 24:00 Uhr hinausgehen
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{1,2}:[0-9]{1,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="INT1">
+		<xs:restriction base="xs:unsignedInt">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="255"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="INT2">
+		<xs:restriction base="xs:unsignedInt">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="65535"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="INT3">
+		<xs:restriction base="xs:unsignedInt">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="16777215"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="INT4">
+		<xs:restriction base="xs:unsignedInt">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="4294967295"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="INT8">
+		<xs:restriction base="xs:unsignedLong">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="18446744073709551615"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="FLOAT1">
+		<xs:annotation>
+			<xs:documentation>englische Notation beachten, z. B. 19 Euro =
+				19.00 Euro
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:decimal">
+			<xs:minInclusive value="0"/>
+			<xs:maxInclusive value="100"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="KoordWgs84_Type">
+		<xs:restriction base="xs:float"/>
+	</xs:simpleType>
+	<xs:simpleType name="Char">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="blobString">
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[ -þ€–]*"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="ID_SortenAttributKlasse_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Definiert die SortenAttributKlasse. Zur Zeit gibt es genau
+				drei SortenAttributKlassen. Das können in Zukunft auch
+				noch mehr werden. 1=Komfortklasse 2=Rabattklasse
+				3=Fahrgasttyp
+			</xs:documentation>
+			<xs:appinfo>
+				<LookUpItem value="1">Komfortklasse</LookUpItem>
+				<LookUpItem value="2">Rabattklasse</LookUpItem>
+				<LookUpItem value="3">Fahrgasttyp</LookUpItem>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:restriction base="tpd:INT4">
+			<xs:minInclusive value="1"/>
+			<xs:maxInclusive value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="Richtungen_Type">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Hin"/>
+			<xs:enumeration value="Rueck"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="ZuordnungRelCodeGrp_Type">
+		<xs:annotation>
+			<xs:documentation>
+				„S“=StartRelCode, 
+				„Z“=ZielRelCode,
+				„R“=StartZielRelCode
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="tpd:Char">
+			<xs:enumeration value="S"/>
+			<xs:enumeration value="Z"/>
+			<xs:enumeration value="R"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="ZusSorteAnbindung_Type">
+		<xs:annotation>
+			<xs:documentation>
+			  „V“=Vorlauf, 
+			  „N“=Nachlauf, 
+			  „H“=Hauptlauf,
+			  „U“=Richtungsungebunden
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="tpd:Char">
+			<xs:enumeration value="V"/>
+			<xs:enumeration value="N"/>
+			<xs:enumeration value="H"/>
+			<xs:enumeration value="U"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="VersionStatus_Type">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="stabil"/>
+			<xs:enumeration value="in Arbeit"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="Tarifobjekttyp_Type">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Ortspunkte"/>
+			<xs:enumeration value="Tarifpunkte"/>
+			<xs:enumeration value="TarifrelevantePunkte"/>
+			<xs:enumeration value="Sorten"/>
+		</xs:restriction>
+	</xs:simpleType>	
+
+	<xs:simpleType name="Sammelbeleg_Type">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="true">
+				<xs:annotation>
+					<xs:documentation>ein Fahrschein für n Personen</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="false">
+				<xs:annotation>
+					<xs:documentation>n Fahrscheine für n Personen</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="auswahl">
+				<xs:annotation>
+					<xs:documentation>Bediener entscheidet, ob ein oder n Fahrscheine
+						gedruckt werden, bei n&gt;1</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+
+		</xs:restriction>
+	</xs:simpleType>
+
+    <xs:simpleType name="Lang_Type">
+    	<xs:annotation>
+    		<xs:documentation>
+    			Für diese Datenlieferungen sind nur 2-Zeichen Iso-Codes nach ISO 639-1:2002 vorgesehen 
+    		</xs:documentation>
+    	</xs:annotation>
+    	<xs:restriction base="xs:language">
+    		<xs:maxLength value="2"/>
+    	</xs:restriction>
+    </xs:simpleType>
+    
+	<!--Allgemein -->
+	<xs:complexType name="Tarifgebiete_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Tarifgebiet ist eine logische Einheit, die alle
+				Tarifelemente eines Tarifgebers
+				zusammenfasst
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_TarifGebiet"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarif" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="BezeichnungKurz" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="BezeichnungLang" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Erstellungsdatum" type="tpd:DateTimeCompact" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Version" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Tarifpunkte_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_TarifGebiet"/>
+					<field name="ID_TarifPunkt"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarif" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TarifPunkt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TarifPunktTyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>1=Zone/Wabe/Ring/Tarifpunkt
+						2=Wabentyp (Zusammenfassung mehrere Elemente von Typ 1)
+						3=Tarifhaltestelle
+						4=Ortsteil (in seiner Funktion als Tarifpunkt)
+						5=Ort (Zusammenfassung mehrere Ortsteile)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Drucktext" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_TarifPunktTypRef" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_TarifPunktRef" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="KA_OrtOrgID" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA Organisationsnumer</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_OrtTyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA Ortstyp</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Tarifpunktmengen_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Tarifpunktmenge"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarif" nillable="true"/>
+
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Tarifpunktmenge" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			
+			
+			<xs:element name="ReferenzExtern" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+				  		Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+				  		identifizieren zu können.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	
+	<xs:complexType name="TarifpunktmengeElemente_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_TarifpunktmengeElement"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Uix_TarifpunktmengeElemente">
+					<field name="ID_Tarifpunktmenge"/>
+					<field name="ID_Tarifpunkt"/>
+					<field name="SortOrder"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<schema name="Tarif" nillable="true"/>
+
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_TarifpunktmengeElement" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_Tarifpunktmenge" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_Tarifpunkt" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="SortOrder" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Zeitraeume_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Gültigkeitszeitraum
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Basis" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ZeitraumVon" type="tpd:DateTimeCompact" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ZeitraumBis" type="tpd:DateTimeCompact" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Tarifkennung" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="HauptZeitraumNr" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Alle Zeiträume mit dem gleichen
+						Hauptzeitraum bilden einen gemeinsamen Datenraum, in dem
+						alle Refrenzen ID_xx die gleiche Bedeutung haben und
+						auflösbar sind.
+						Sind zu einem Zeitpunkt mehrere Zeiträume mit unterschiedlichen
+						Hauptzeitraumnummern gültig, hat der mit der höheren
+						Hauptzeitraumnummer Vorrang.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SubZeitraumNr" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Die Subzeitraumnummer ist innerhalb einer
+						Hauptzeitraumnummer ununterbrochen, aufsteigend nummeriert,
+						beginnend mit 1.
+						Bei gleichzeitiger Gültigkeit mehrere Subzeiträume hat die höhere
+						SubZeitraumNr Vorrang vor der kleineren.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="ZeitraumOptionen_Type">
+		<xs:annotation>
+			<xs:documentation>
+				ordnet einem Zeitraum zusätzliche Optionen zu
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Zeitraum"/>
+					<field name="ID_Schluessel"/>
+				</primekey>
+				<schema name="Basis" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_Schluessel" type="xs:string" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Wert" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Kalender_Type">
+		<xs:annotation>
+			<xs:documentation>Kalender mit zugeordneten Tagesarten.
+			Ein Betriebstag ist ein Kalendertag, kann aber abweichende Tagesanfang und -ende haben.
+			Tagesanfang und -ende werden nicht explizit im Kalender definiert.
+			
+			Benötigt das System für eine Funktionalität eine ID_Tagesart, dann ermittelt es diese aus dem Kalender.
+            Ist für einen konkreten Kalendertag kein Eintrag im Kalender vorhanden, kann das System über 
+            geeignete Tagesartmerkmalelemente eine Default Tagesart aufgrund des Wochentages und allgemein berechenbarer 
+            Feiertage ermittelt werden. 
+            
+            Siehe auch Tagesmerkmale_Type, Tagesmerkmalelemente_Type und Tagsartmerkmalelemente_Type.
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_BetriebsTag"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_Kalender_BTagArt">
+					<field name="ID_BetriebsTagesArt"/>
+					<field name="ID_BetriebsTag"/>
+				</index>
+				<schema name="Angebot" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_BetriebsTag" type="tpd:DateCompact" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Datum des Betriebstages</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_BetriebsTagesArt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Tagesart des Betriebstages
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Tagesarten_Type">
+		<xs:annotation>
+			<xs:documentation>Eine Tagesart beschreibt den logischen Charakter eines Tages soweit der für das vorliegende System benötigt wird.
+			Einem Kalendertag ist genau eine Tagesart zugeordnet.
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_BetriebsTagesArt"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Angebot" nillable="true"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_BetriebsTagesArt" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Kennung der Tagesart</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Informationen, welche Bedeutung diese
+						Kennung hat.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Tagesmerkmale_Type">
+		<xs:annotation>
+			<xs:documentation>Ein Tagesmerkmal muss so gestaltet sein, dass an jedem 
+			Betriebstag (Kalendertag aber ggf. abweichende Start-/Ende Uhrzeit) aus der 
+			Liste der Mermalelemente genau ein Element gültig ist.
+			
+			Für eine Tagesart können mehrere Elemente aus einer Liste eines Tagesmerkmales definiert sein.	
+			
+			Beispiele:
+			Tagesmerkmal:"Wochentag=("Mo","Di","Mi","Do","Fr","Sa","So")
+			Tagesmerkmal:"Ferien"=("Ja","Nein")			
+			
+			Die Husst Schnittstelle definiert ein Default-Tagesmerkmal mit dem vorgegebenen Bezeichner
+			"husstDefaultermittlung"=("Mo","Di","Mi","Do","Fr","Sa","So","Mo/Feiertag","Di/Feiertag","Mi/Feiertag","Do/Feiertag","Fr/Feiertag","Sa/Feiertag","So/Feiertag")
+			Mit diesem Tagesmerkmal können Tagesarten ausgezeichnet werden, die dann gelten sollen,
+			wenn kein Kalendereintrag gefunden wird. Das Vertriebssystem ermittelt dann aufgrund des Wochentages und der
+			allgemein berechenbaren Feiertage (Einige sind natürlich nicht eindeutig ermittelbar) das husstDefault-Tagesmerkmal
+			und sucht eine Tagesart, für die dieses Merkmal gesetzt ist. Maximal vierzehn Tagesarten können darüber
+			unterschieden werden und keine zwei Tagesarten dürfen eines der Merkmale gemeinsam haben).
+			
+			Das Tagesmerkmal "husstDefaultermittlung" muss nicht definiert werden. Wenn eine Datenmenge das Merkmal definiert, 
+			darf es nur mit der hier definierten Intension verwendet werden.
+			
+			Alle anderen Tagesartmerkmal haben lediglich deklarativen Charakter. Eine vorgegebene Behandlung oder
+			Auswertung ist über den HUSST-Standard nicht definiert.								
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Tagesmerkmal"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Angebot" nillable="true"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Tagesmerkmal" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Kennung des Tagesmerkmals</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Bezeichnungen mit dem Prefix "husst" sind reserviert.
+					
+					Die Bezeichnung "husstDefaultermittlung" hat eine definiert Bedeutung (Siehe Tagesmerkmale_Type).
+					Ansonsten kann die Bezeichnung frei vergeben werden. 
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="TagesmerkmalElemente_Type">
+		<xs:annotation>
+			<xs:documentation>Jedes Tagesmerkmal definiert eine Liste mit unterschiedlichen Tagesmerkmal Elementen.
+			Siehe auch Tagesmerkmale_Type. 
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_TagesmerkmalElement"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+ 				<index name="Idx_TagMerkEl_Main">
+					<field name="ID_TagesmerkmalElement"/>
+					<field name="ID_Tagesmerkmal"/>
+				</index>
+				<schema name="Angebot" nillable="true"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TagesmerkmalElement" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Kennung des Tagesmerkmalelements</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Tagesmerkmal" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Kennung des Tagesmerkmals</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Eindeutiger Bezeichner des Tagesartmerkmalelements</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="TagesartMerkmalElemente_Type">
+		<xs:annotation>
+			<xs:documentation>TagesartMerkmalElemente vernknüpfen eine Tagesart mit einer Menge von 
+			Tagesmerkmal-Elementen. 
+
+            Damit beschreibt die Datenmenge lediglich formal die Intension der Tagesart.
+            Lediglich für die Elemente des Tagesmerkmals "husstDefaultermittlung" ist eine funktionale
+            Bedeutung definiert (siehe Tagesmerkmale_Type).
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_TagesartMerkmalElement"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+ 				<index name="Idx_TagartMerkEl_Main">
+					<field name="ID_TagesmerkmalElement"/>
+					<field name="ID_BetriebsTagesArt"/>
+				</index>
+				<schema name="Angebot" nillable="true"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TagesartMerkmalElement" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Kennung des Tagesartmerkmalelements</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_BetriebsTagesArt" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Kennung des ID_BetriebsTagesArt</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_TagesmerkmalElement" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Kennung des Tagesmerkmalelements</xs:documentation>
+				</xs:annotation>
+			</xs:element>			
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="IdentobjektTypen_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Auflistung der verschiedenen Objekttypen, die
+				zur Identifizierung einer Person eingesetzt werden
+				Defaultwerte
+				sind:
+				1=Fahrermodul
+				2=Chipkarte
+				3=Schlüssel
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_IdentobjektTyp"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Personal" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_IdentobjektTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Nummer des Ident-Objekt Typs
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichner" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Identobjekte_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Ident Objekte zur Identifizierung einer Person.
+				Die ID des Identobjektes ist über alle Objekttypen und Mandanten
+				eindeutig zu halten.
+
+				Idealerweise sollten alle Identobjekte eines Objekttyps über alle Mandanten im
+				System eindeutig sein.
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Identobjekt"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_IdentObj_Type">
+					<field name="Identobjekt_Schluessel"/>
+					<field name="ID_IdentobjektTyp"/>
+					<field name="ID_Unternehmen"/>
+				</index>
+				<schema name="Personal" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Identobjekt" type="xs:string" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>systemweit eindeutige Nummer/Kennung des
+						Ident-Objektes
+						z.B. zusammengesetzt aus ID_Identobjekttyp und Identobjekt_Schluessel
+						ggf. mit ID_Unternehmen
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_IdentobjektTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Nummer des Ident-Objekt Typs
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Unternehmen" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Nummer des Unternehmens, dem das Identobjekt
+						zugeorndet ist
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Identobjekt_Schluessel" type="xs:string" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Objektspezifische Kennung (z.B. Modulnummer
+						oder Chipkartennummer, etc.)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichner" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Freier Text, der z.B. zur Anzeige verwendet
+						werden kann.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="PersonalIdentobjekte_Type">
+		<xs:annotation>
+			<xs:documentation>
+				PersonalIdentobjekte weist einer Person kein,
+				ein oder mehrere Identobjekte zu.
+				Hinweis: Es handelt sich um
+				eine n:m Beziehung. Auf einen künstlichen Schlüssel wird
+				verzichtet.
+				Die Struktur hat deshalb keinen PrimeKey!
+
+				Einer Person kann ein Identobjekt auch mehrfach zugeordnet sein, mit
+				unterschiedlichen
+				AktivAb, AktivBis Intervallen. Ein Identobjekt
+				darf immer dann zur Identifikation verwendet werden,
+				wenn bei
+				mindestens einem Zuordnungsobjekt der aktuelle Systemzeitpunkt
+				im AktivAb,AktivBis Intervall
+				liegt. Ist AktivAb nicht angegeben,
+				gilt die Zuordnung ab "schon immer", ist AktivBis nicht
+				angegeben
+				gilt die Zuordnung "bis ewig".
+			</xs:documentation>
+			<xs:appinfo>
+				<primkey/>
+				<index name="Idx_IdentObj_Personal">
+					<field name="ID_Identobjekt"/>
+					<field name="ID_Personal"/>
+				</index>
+				<schema name="Personal" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Identobjekt" type="xs:string" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>systemweit eindeutige Nummer/Kennung des
+						Identobjektes
+						z.B. zusammengesetzt aus ID_Identobjekttyp und Identobjekt_Schluessel
+						ggf. mit ID_Unternehmen
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Personal" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Personal-Nr</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Ausgabedatum" type="tpd:DateCompact" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Zeitpunkt, zu dem das Identobjekt ausgegeben
+						wurde.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AktivAb" type="tpd:DateCompact" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Wenn angegeben, definiert AktivAb den Beginn
+						der Verwendbarkeit des Ident-Objektes.
+						Vor diesem Zeitpunkt darf sich der Bediener mit diesem Objekt nicht
+						erfolgreich am System anmelden können.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AktivBis" type="tpd:DateCompact" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Wenn angegeben, definiert AktivBis das Ende
+						der Verwendbarkeit des Ident-Objektes.
+						Nach diesem Zeitpunkt darf sich der Bediener mit diesem Objekt nicht
+						erfolgreich am System anmelden können.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Personal_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Personalstammdaten
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Personal"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_Pers_Aktiv">
+					<field name="ID_Personal"/>
+					<field name="Aktiv"/>
+				</index>
+				<index name="Idx_Pers_GueltigAb">
+					<field name="GueltigAb"/>
+				</index>
+				<index name="Idx_Pers_GueltigBis">
+					<field name="GueltigBis"/>
+				</index>
+				<schema name="Personal" nillable="false"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Personal" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>PersonalNr</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Unternehmen" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Arbeitgeber</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_AbrUnternehmen" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Abrechnungs-Unternehmen, bei dem Einnahmen
+						abgeliefert werden müssen
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Passwort" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>kt definiert den HashWert</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Vorname" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Nachname" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Aktiv" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="GueltigAb" type="tpd:DateTimeCompact" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="GueltigBis" type="tpd:DateTimeCompact" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Personaleinsatz_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Geräte- und Rollenzuordnung zu Personal
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Personal"/>
+					<field name="ID_GeraeteTyp"/>
+					<field name="ID_GeraeteEinsatzTyp"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_PersEin_GTyp">
+					<field name="ID_GeraeteTyp"/>
+					<field name="ID_GeraeteEinsatzTyp"/>
+				</index>
+				<schema name="Personal" nillable="false"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Personal" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>PersonalNr</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_GeraeteTyp" type="xs:string" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_GeraeteEinsatzTyp" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_EinsatzArt" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Rolle, die er auf dem Gerätetyp
+						einnimmt
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Standort_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<schema name="Personal" nillable="true"/>
+			</xs:appinfo>
+			<xs:documentation>
+				Gerätestandort
+			</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Standort" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Geraet_Type">
+		<xs:annotation>
+			<xs:documentation>Geräteverwaltung</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_GeraeteTyp"/>
+					<field name="ID_Geraet"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_GeraeteTyp_Geraet">
+					<field name="ID_Geraet"/>
+				</index>
+				<schema name="Personal" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Geraet" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>GeräteNr</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_GeraeteTyp" type="xs:string" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Info" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="kaKVP" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA KVP Nr</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="GeraetEinsatztypen_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Zur Kennzeichnung der Tarifverteilung
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_GeraeteEinsatzTyp"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Personal" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_GeraeteEinsatzTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Info" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<!--Relationen -->
+	<xs:complexType name="Interpretationen_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Interpretationen definiert, wie die Daten zu
+				interpretieren sind.
+				Dazu werden Parameter mit einem
+				ID_Schluessel und einem Wert eingetragen.
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Schluessel"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Basis" nillable="true"/>
+				<schema name="Tarif" nillable="false"/>
+								
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Schluessel" type="xs:string" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Wert" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Relationscodes_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Relationscodes fassen Tarifpunkte mehrerer
+				Tarifgeber zusammen. Damit können
+				einzelnen Orten/Haltestellen
+				unterschiedlich viele Tarifpunkte
+				unterschiedlicher Tarifgeber
+				zugeordnet werden
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_RelCode"/>
+					<field name="ID_Zeitraum"/>
+					<field name="ID_TarifGebiet"/>
+					<field name="ID_TarifPunkt"/>
+				</primekey>
+				<schema name="Tarif" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_RelCode" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_TarifPunkt" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Relationscodegruppen_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Zusammenfassung von Relationscodes bspw. für
+				City Option
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_RelCodeTyp"/>
+					<field name="ID_RelCodeGruppe"/>
+					<field name="ID_Zeitraum"/>
+					<field name="ID_RelCode"/>
+				</primekey>
+				<schema name="Tarif" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_RelCodeTyp" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_RelCodeGruppe" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_RelCode" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="RaeumlicheGueltigkeit_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Definition der räumlichen Gültigkeit für KA
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Zeitraum"/>
+          			<field name="ID_Start_TarifGebiet"/>
+          			<field name="ID_Start_TarifPunktTyp"/>
+					<field name="ID_Start_TarifPunkt"/>
+          			<field name="ID_TarifGebiet"/>
+					<field name="ID_PreisStufe"/>
+					<field name="KA_RaeumlicheCodierung"/>
+          			<field name="ID_Ziel_TarifGebiet"/>
+          			<field name="ID_Ziel_TarifPunktTyp"/>
+					<field name="ID_Ziel_TarifPunkt"/>
+				</primekey>
+				<index name="Idx_RaeumlGuelt_Main">
+					<field name="ID_Zeitraum"/>
+          			<field name="ID_Start_TarifGebiet"/>
+          			<field name="ID_Start_TarifPunktTyp"/>
+					<field name="ID_Start_TarifPunkt"/>
+          			<field name="ID_TarifGebiet"/>
+					<field name="ID_PreisStufe"/>
+					<field name="KA_RaeumlicheCodierung"/>
+          			<field name="ID_Ziel_TarifGebiet"/>
+          			<field name="ID_Ziel_TarifPunktTyp"/>
+					<field name="ID_Ziel_TarifPunkt"/>
+				</index>
+				<schema name="Tarif" nillable="true"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_RaeumlGueltDS" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Eindeutige Datensatz-ID innerhalb der ID_Zeitraum</xs:documentation></xs:annotation></xs:element>
+			<xs:element name="ID_Start_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Start_TarifPunktTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Start_TarifPunkt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_PreisStufe" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="KA_RaeumlicheCodierung" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Ziel_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Ziel_TarifPunktTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Ziel_TarifPunkt" type="tpd:INT4" nillable="true" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="KA_GueltigkeitsRaum" type="tpd:blobString" nillable="false" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>projektspezifische Hinterlegung der
+						Beschreibung der räumlichen Gültigkeit für den KA EFS
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Vertriebswege" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Bitfeld Vertriebswege</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_ViaNr" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Nummer der Viatexte für diese
+						Verbindung
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Tarifpunktmenge" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Referenz  auf eine Tarifpunktmenge.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+
+	<xs:complexType name="Relationen_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Relation auf Relationscode Ebene
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Relation"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="IDX_REL_START_ZIEL">
+					<field name="ID_RelCode_Start"/>
+					<field name="ID_RelCode_Ziel"/>
+					<field name="ID_Zeitraum"/>
+					<SortOrder/>
+				</index>
+				<schema name="Tarif" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Relation" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_RelCode_Start" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_RelCode_Ziel" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="SortOrder" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Variantenzählung - Bestimmt die Reihenfolge der Vias in
+						der Auswahl
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_TeilRelation" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>bis einschließlich Verison 1.34 verweisen
+						Relationen mit ihrer ID_Relation auf ihre TeilRelationen - ab 1.35
+						haben Teilrelationen einen eigenen Schlüssel ID_TeilRelation.
+						Damit können mehrere Relationen auf die gleichen Teilrelationen
+						verweisen.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="GegenrichtungLiegtVor" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Vertriebswege" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Bitfeld Vertriebswege</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_ViaNr" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Nummer der Viatexte für diese Verbindung
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Vias_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Gesamt Relationsinformation
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_ViaNr"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarif" nillable="false"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_ViaNr" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Anzeigetext" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Text zur Auswahl der Variante, Teilstrecken
+						mit '*' getrennt
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Drucktext" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Drucktext, Teilstrecken mit '*' getrennt
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Anzeigetext_Rueck" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Text zur Auswahl der Variante in der
+						Rückrichtung, Teilstrecken mit '*' getrennt
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Drucktext_Rueck" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Drucktext in der Rückrichtung,
+						Teilstrecken mit '*' getrennt
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="TeilRelationen_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Relation (und Teilrelation) auf Tarifpunkt Ebene
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_TeilRelationDS"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_TR_Main">
+					<field name="ID_TeilRelation"/>
+					<field name="ID_Zeitraum"/>
+					<field name="ID_Tarifart"/>
+					<field name="SortOrder"/>
+				</index>
+				<index name="Idx_TR_StartTarifpunkt">
+					<field name="ID_Start_TarifGebiet"/>
+					<field name="ID_Start_TarifPunkt"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<index name="Idx_TR_ZielTarifpunkt">
+					<field name="ID_Ziel_TarifGebiet"/>
+					<field name="ID_Ziel_TarifPunkt"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<index name="Idx_TR_Pst">
+					<field name="ID_TarifGebiet"/>
+					<field name="ID_PreisStufe"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<schema name="Tarif" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TeilrelationDS" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TeilRelation" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="SortOrder" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Reihenfolge der Vias innerhalb der Relation.
+						Präzisierung: Reihenfolge der
+						Gesamtrelation für Anzeige/Auswahl != ID_POS in
+						Teilrelationen (= Reihenfolge der Vias innerhalb
+						der Relation)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Start_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_Start_TarifPunkt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_Start_TarifPunktTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="Start_TarifPunktName" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Ziel_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_Ziel_TarifPunkt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_Ziel_TarifPunktTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="Ziel_TarifPunktName" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_PreisStufe" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_Preisquelle" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_TarifArt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Tarifart (0=Allgemein, 1=Bartarif, 2=Zeittarif)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Komfortklasse" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						(z.B. 1.Kl., 2.Kl., ...) Verweis auf
+						Sortenattributgruppen.AttributText
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AlternativePreisGruppe" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="EinnahmeAufteilung" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ViaDrucktext" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						alternativer Via-Drucktext, hat Vorrang vor dem
+						Drucktext des Via-Datensatzes
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ViaDrucktext_Rueck" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						alternativer Via-Drucktext für den umgekehrte
+						Streckenverlauf, hat Vorrang vor dem
+						Drucktext_Rueck des Via-Datensatzes. Wenn
+						ViaDrucktext_Rueck leer ist, aber ViaDrucktext
+						gefüllt hat ViaDrucktext Vorrang vor
+						Drucktext_Rueck bzw. Drucktext des
+						Via-Datensatzes.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_startOrtOrgID" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Ort Organisationsnummer
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_startOrtTyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA Ortstyp</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_startOrtNummer" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA OrtNr</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_zielOrtOrgID" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Ort Organisationsnummer
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_zielOrtTyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA Ortstyp</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_zielOrtNummer" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA OrtNr</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Linie" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="RelationsIDTarifgeber" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Referenz der zugrunde liegenden Information zu
+						einer Datenmenge des Tarifgebers.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0">
+			  <xs:annotation>
+			    <xs:appinfo>
+			      
+			    </xs:appinfo>
+			  </xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Nachbarhaltestellen_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Definition von Haltestellengruppen für
+				Kurzstrecken/Zahlgrenzen
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_OrtspunkttypVon"/>
+					<field name="ID_OrtspunktVon"/>
+					<field name="ID_OrtspunkttypNach"/>
+					<field name="ID_OrtspunktNach"/>
+					<field name="SortOrder"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_NachbarHst_PstTg">
+					<field name="ID_TarifGebiet"/>
+					<field name="ID_PreisStufe"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<schema name="Tarif" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_OrtspunkttypVon" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_OrtspunktVon" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Haltestellennummer, für die eine
+						Nachbbarbeziehung
+						definiert wird (kleinere Nummer des Paares,
+						bei Halbmatrix)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_OrtspunkttypNach" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_OrtspunktNach" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Haltestellennummer, für die eine
+						Nachbbarbeziehung
+						definiert wird (größere Nummer
+						des Paares, bei
+						Halbmatrix)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element name="SortOrder" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_ViaNr" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Tarifgebiet, für das eine
+						Nachbarhaltestelle definiert
+						wird
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_PreisStufe" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Zuordnung Preisstufe</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Zahlgrenzen" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Anzahl der Zahlgrenzen</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="PreisstufenDirektwahl_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Definition von Haltestellengruppen für
+				Kurzstrecken/Zahlgrenzen
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_PstDirektDS"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_PstDirekt_Main">
+					<field name="ID_Schluesselwert"/>
+					<field name="ID_Tarifart"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<index name="Idx_Relation">
+					<field name="ID_Relation"/>
+				</index>
+				<schema name="Angebot" nillable="true"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+            <xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="ID_PstDirektDS" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Datensatz-Schlüssel - eindeutig innheralb der ID_Zeitraum
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+            <xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+            <xs:element name="ID_Schluesselwert" type="xs:string" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Schlüsselwert, über den die Pst-Direktwahl
+						gefunden wird. Projektspezifisch definiert.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+
+			<xs:element name="ID_TarifArt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Tarifart (0=Allgemein, 1=Bartarif,
+						2=Zeittarif)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_TarifGebiet_PreisStufe" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Zuordnung Tarifgebiet der Preisstufe
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_PreisStufe" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Zuordnung Preisstufe</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Anzeigetext" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Text zur Anzeige der Preisstufendirektwahl
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Drucktext" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Drucktext
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Relation" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Vertriebswege" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Bitfeld Vertriebswege</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<!--Produkte -->
+	<xs:complexType name="Preisspalten_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Preiszusätze für die Preisfindung
+				(bspw. Rabattierungen)
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_PreisSpalte"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarif" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_PreisSpalte" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Waehrungscode" type="xs:string" nillable="false" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						ISO-Kennung (dezimal) der Währung -
+						außer
+						EUR=999
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Preisspaltenkennung" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Kennung (Nr) zur systematischen
+						Interpretation (dflt=0)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Spaltenüberschrift
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BezeichnungKurz" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="Hinweis" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Info zur Preisspalte</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Preisstufen_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_TarifGebiet"/>
+					<field name="ID_PreisStufe"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_Schluesselwert">
+					<field name="ID_Schluesselwert"/>
+					<field name="ID_TarifGebiet"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<schema name="Tarif" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_PreisStufe" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Schluesselwert" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="BezeichnungKurz" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="BezeichnungLang" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="WegstreckeInMetern" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						durschnittliche Wegstrecke in Meter für
+						PKM Berechnung
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_MwSt" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Nummer des Mehrwertsteuersatzes
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="UpgradeStopp" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Ein Preisupgrade kann bis zu einschließlich
+						dieser Preisstufe erfolgen.
+						Es können mehrere Stopps eingebaut sein.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PstLayoutTyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Die Interpretation des PstLayoutTyps ist
+						stark projektspezifisch und erlaubt die Definition
+						von
+						Layout-Hinweisen aufgrund der Preisstufe
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+            <xs:element name="SortOrder" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="SortenTarifarten_Type">
+		<xs:annotation>
+			<xs:documentation>
+				N:M Zuordnung - Sorte / Tarifart
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Sorte"/>
+					<field name="ID_Tarifart"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarif" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_Sorte" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Nummer der Sorte, eindeutig über alle
+						Tarifgebiete innerhalb des ID_Zeitraum bzw. des
+						Haupt-ID_Zeitraum
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_TarifArt" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Tarifart (siehe Hilfstabelle Tarifart)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Sorten_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Artikel/Produkte/Fahrscheintypen
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Sorte"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_So_Tarifgebiet">
+					<field name="ID_TarifGebiet"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<index name="Idx_So_Tarifgeber">
+					<field name="SorteTarifgeber"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<index name="Idx_So_Komfortklasse">
+					<field name="Komfortklasse"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<index name="Idx_So_Rabattklasse">
+					<field name="Rabattklasse"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<index name="Idx_So_Fahrgasttyp">
+					<field name="Fahrgasttyp"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<schema name="Tarif" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Sorte" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Nummer der Sorte, eindeutig über alle
+						Tarifgebiete und Tarifversionen
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Sortenklasse" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+
+			<xs:element name="SorteTarifgeber" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Schlüssel des Tarifgebers für diese
+						Sorte
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BezeichnungKurz" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Verwendung: Identifikation / optional Druck
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="BezeichnungLang" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Verwendung: Identifikation / optional Druck
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="AnzeigeKurz" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						Verwendung: Produktanwahl
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="AnzeigeLang" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						Verwendung: Produktanwahl / Warenkorb
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="KundendisplayKurz" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						Verwendung: Kundendisplay
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="KundendisplayLang" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						Verwendung: Kundendisplay
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="BelegdruckKurz" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						Verwendung: Belegdruck
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="BelegdruckLang" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						Verwendung: Belegdruck
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="Ausgabeoption" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Bit-Feld das definiert, auf welche Arten die
+						Sorte ausgegeben werden darf. 
+						0x00000001 = Fahrschein darf ausgedruckt werden 
+						0x00000002 = Fahrschein auf Chipkarte ablegbar 
+						0x00000004 = frei 
+						0x00000008 = frei 
+						0x00000010 = frei
+						0x00000020 = frei 
+						0x00000040 = frei 
+						0x00000080 = frei 
+						0x00000100 = frei 
+						0x00000200 = frei
+						0x00000400 = frei 
+						0x00000800 = frei 
+						0x00001000 = frei 
+						0x00002000 = frei 
+						0x00004000 = frei
+						0x00080000 = frei 
+						0x00010000 = drucke parallel zum FS auf der Chipkarte einen Papierfahrschein
+						0x00020000 = frei 
+						0x00040000 = frei 
+						0x00080000 = frei 
+						0x00080000 = frei 
+						0x00100000 = frei
+						0x00200000 = frei 
+						0x00400000 = frei 
+						0x00800000 = frei 
+						0x01000000 = frei 
+						0x02000000 = frei
+						0x04000000 = frei 
+						0x08000000 = frei 
+						0x10000000 = frei 
+						0x20000000 = frei 
+						0x40000000 = frei
+						0x80000000 = frei
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Druckoption" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						0:Druck über Layout bzw. LayoutBeleg 
+						1:Druck	über ein zum Verkaufszeitpunkt zugeordnetes
+						Hauptprodukt 2:Druck über ein zum
+						Verkaufszeitpunkt zugeordnetes Hauptprodukt oder
+						über Layout bzw. LayoutBeleg, wenn kein
+						Hauptprodukt zugeordnet wurde 
+						3:Druck eines 2. Fahrscheins mit einer Druckinformation 
+						"2.	Druck" die im Layout ausgewertet werden kann.
+						99:Nicht Drucken
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Layout" type="tpd:blobString" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Layoutdefinition für den Ausdruck des Produktes
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="LayoutBeleg" type="tpd:blobString" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Layouthinweise für den Ausdruck eines
+						Einzelbeleges.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BelegAnzahl" type="tpd:INT4" maxOccurs="1" nillable="true" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Wieviele Einzelbelege sind für dieses Produkt zu
+						erstellen? 0..n
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Sammelbeleg" type="tpd:Sammelbeleg_Type" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Soll das Produkt auf einem Sammelbeleg
+						aufgeführt werden? Ja/Nein
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Vertriebswege" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Bitfeld Vertriebswege
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_MwSt" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ZahlungsArt" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Bit-Feld das definiert, auf welche Arten die
+						Sorte bezahlt werden darf. Das Verkaufsgerät
+						definiert ggf. weiter Einschränkungen, die sich
+						aus Konfiguration und Bedienung ergeben.
+
+						Wenn das Feld nicht gefüllt ist, gilt keine
+						explizite Einschränkung für die Sorte.
+						0x00000001 = Barzahlung 0x00000002 = frei
+						0x00000004 = Geldkartenzahlung 0x00000008 =
+						ec-Cash 0x00000010 = ec Lastschrift 0x00000020 =
+						frei 0x00000040 = kundeneigene Pre-Paid-Zahlung
+						(z.B. LEGIC) 0x00000080 = kundeneigene
+						Pre-Paid-Zahlung ( Reserve ) 0x00000100 = frei
+						0x00000200 = Pre-Paid-Zahlung Verbund (z.B.:
+						DING) 0x00000400 = Pre-Paid-Zahlung Verbund (
+						Reserve ) 0x00000800 = frei 0x00001000 =
+						Rechnungszahlung 0x00002000 = frei 0x00004000 =
+						Visa 0x00080000 = Euro-/MasterCard 0x00010000 =
+						American Express 0x00020000 = Diners Club
+						0x00040000 = Maestro 0x00080000 = Kreditkarte (
+						Reserve ) 0x00080000 = frei 0x00100000 =
+						Post-Paid-Zahlung(z.B.: BOB) 0x00200000 =
+						Post-Paid-Zahlung( Reserve ) 0x00400000 = frei
+						0x00800000 = Sonstige Zahlung 0x01000000 = frei
+						0x02000000 = Gutschein 0x04000000 = frei
+						0x08000000 = frei 0x10000000 = frei 0x20000000 =
+						frei 0x40000000 = frei 0x80000000 = frei
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Komfortklasse" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						(z.B. 1.Kl., 2.Kl., ...) Verweis auf
+						Sortenattributgruppen.AttributText
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Rabattklasse" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						zum Beispiel: Bahncard/Bahncard 25/SH-Card Die
+						Rabattklassen schließen sich gegenseitig aus.
+						Verweis auf Sortenattributgruppen.AttributText
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Fahrgasttyp" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						normal Kind Schüler Azubi Verweis auf
+						Sortenattributgruppen.AttributText
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SortenTyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						1=Tageskarte,2=Wochenkarte,3=Monatskarte,4=Halbjahreskarte,5=Jahreskarte,6=Mehrfahrten,0=Einzelkarte,7=Bargutschrift,8=AboEinzahlung,9=EBEEinzahlung
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Zusatzsorte" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						TRUE, wenn die Sorte eine Zusatzsorte ist, dann
+						gibt es ein Objekt des Typs Zusatzsorten_Type
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Mindestpersonenanzahl" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Ab wievielen Personen darf der Fahrschein
+						verkauft werden
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Hoechstpersonenanzahl" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Bis zu wievielen Personen darf der Fahrschein
+						maximal verkauft werden
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KdNummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Definiert, ob und in welchem Format eine
+						Kundennummer zu erfassen ist. Das Format
+						definiert, wieviele und welche Zeichen erfasst
+						werden können: a: -&gt; mit diesem Hinweis muss der
+						Formatstring beginnen, er definiert die folgende
+						Syntax ?=steht für ein beliebiges Zeichen
+						#=steht für eine Zahl $=steht für eine beliebige
+						Zahl oder ein beliebiger Buchstabe (ohne
+						Sonderzeichen ohne Leerzeichen) Optionale
+						Zeichen sind mit [] einzufassen Beispiel:
+						a:##$$[??????] es müssen zwei Ziffern, gefolgt
+						von zwei Ziffern oder Buchstaben gefolgt von bis
+						zu 6 beliebigen Zeichen eingegeben werden.
+						a:#[#########] eine Zahl mit mindestens einer
+						und max. 10 Ziffern a:[##########] eine
+						beliebige Zahl mit max. 10 Ziffern - Eingabe ist
+						optional
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="GueltigRegel" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						1=KW/KM/KJ (fest), 2=gleitend - nächste Einheit
+						-1, 3=Anzahl Tage/Monate
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="GueltigParam" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						bei GRegel 3: Anzahl Tage/Monate
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="GueltigText" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string"/>
+			<xs:element name="GueltigRegelEFS" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						1=KW/KM/KJ (fest), 2=gleitend - nächste Einheit
+						-1, 3=Anzahl Tage/Monate
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="GueltigParamEFS" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						bei GRegel 3: Anzahl Tage/Monate
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="Vorverkauf" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Wieviele Tage im Voraus verkaufbar
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Umschalttag" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						ab welchem Tag, wird der nächste feste Zeitraum
+						angeboten (GRegel=1)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PreisuebergangVorverkauf" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						Gibt an, wie lange die Sorte im Vorverkauf mit
+						dem aktuellen Preis verkauft wird, obwohl ihre
+						Gültigkeit schon im neuen Tarif liegt.
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="Preisfindung" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Hinweis zur Preisfindung 1=Festpreis,
+						2=Relationsbezogen, 3=Relationsbezogen mit
+						Preisstufenupgrade
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Preisabschlussberechnung" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Definiert die Regel(n), nach der ein ermittelter
+						Fahrscheinpreis am Ende noch einmal gegen
+						generelle Preisnormen abgeglichen wird. Z.B.:
+						Mindespreis, Rundung, etc...
+
+						wenn keine Regel angegeben ist, gilt der
+						ermittelte Preis
+
+						Die Definition der Regeln ist in der
+						Dokumentation hinterlegt.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AnzahlBerechtigungen" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Anzahl Fahrtberechtigungen bei SortenTyp 6
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="AnzahlAbschnitte" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Anzahl FSAbschnitte bei SortenTyp 6
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="HinUndRueckfahrt" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="TarifInfo" type="tpd:blobString" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="Drucktext1" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+						Drucktext Verwendung ist abhängig von der
+						Layoutdefinition
+					</xs:documentation>
+				</xs:annotation>
+
+			</xs:element>
+			<xs:element name="Drucktext2" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string"/>
+			<xs:element name="Drucktext3" nillable="true" minOccurs="0" maxOccurs="1" type="xs:string"/>
+			<xs:element name="KA_ReferenzEFS" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA EFS Struktur</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_ProdOrgID" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Produkt Organisationsnummer
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_ProdNr" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA Produkt</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_Infotext" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="KA_Fahrgasttyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA Fahrgasttyp</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_Mitnahme" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA Mitnahme</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_Verkehrsmittel" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Verkehrsmittel
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_Serviceklasse" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Serviceklasse
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0">
+			  <xs:annotation>
+			    <xs:appinfo>
+			      
+			    </xs:appinfo>
+			  </xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Zusatzsorten_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Sorte"/>
+					<field name="ID_PreisStufe"/>
+					<field name="ZuordnungRelCodeGrp"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+        <schema name="Tarif" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Sorte" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ZuordnungRelCodeGrp" type="tpd:ZuordnungRelCodeGrp_Type" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Anbindung" type="tpd:ZusSorteAnbindung_Type" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Zusatzsortentyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>(Bedeutung projektspezifisch.
+						MENT:1=Flächenanstoß, 2=Zusatzanstoß, 3=Streckenanstoß)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_PreisStufe" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Fremdschlüssel zur Produktbildung - wenn
+						angegeben, wird diese Preisstufe fest zur Preisbestimmung
+						verwendet.
+						Die Angabe hat Vorrang vor ID_PreisstufenGrenze.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_PreisstufeGrenze" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>wenn nicht vorhanden (und ID_Preisstufe
+						nicht vorhanden) - alle Preisstufen möglich
+						sonst alle Preisstufen mit ID_Preisstufe kleiner gleich
+						ID_PreisstufeGrenze
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Hinweistext" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						z.B. für Zusatzinfo auf Quittungsausdruck – nicht bei Direktverkauf!
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_SortengruppeHauptsorten" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Verweis auf SortenGruppe mit erlaubten
+						Hauptsorten
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_RelCodeGruppeStart" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Verweis auf RelCodeGruppe die erlaubte
+						RelCode_Start der Hauptrelation gruppiert = Vorlauf
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_RelCodeGruppeZiel" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Verweis auf RelCodeGruppe die erlaubte
+						RelCode_Ziel der Hauptrelation gruppiert = Nachlauf
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Direktverkauf" type="xs:boolean" nillable="false" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>False=“immer mit Hauptsorte“,
+						True=“Direktverkauf ohne Hauptsorte, falls Verkaufsort in
+						Gruppierung durch VerkaufsRelCode enthalten
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<!-- prepared if necessary 10.10.2012 hneubauer im Datenmodell LTN existiert 
+				mit Tb_Anstoss.C_EINHEIT ein Schalter, der aussagt, ob das Anzahl verkaufter 
+				Anstoßprodukte an die Anzahl der zugrundeliegenden Hauptfahrscheine gebunden 
+				ist, oder frei definiert werden kann. Falls dieses Verhalten wirklich gebraucht 
+				wird (Hr. Block, Vorläuferläufergesellschaft wollte das lt. Aussage bei der 
+				Sitzung am 5.10. in Cloppenburg klären) schlagen wird das folgende Element 
+				vor: <xs:element name="GebundeneAnzahl" type="xs:boolean" nillable="false"> 
+				<xs:annotation> <xs:documentation>False=“Anzahl Anschlussprodukte kann frei 
+				editiert werden“, True=“Anzahl Anschlussprodukte ist identisch mit Anzahl 
+				in Hauptsorte"</xs:documentation> </xs:annotation> </xs:element> -->
+		</xs:sequence>
+	</xs:complexType>
+
+
+	<xs:complexType name="Preise_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_PreisDS"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_Pr_Main">	
+					<field name="ID_PreisStufe"/>
+					<field name="ID_Sorte"/>
+					<field name="ID_PreisSpalte"/>
+					<field name="ID_TarifGebiet"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<schema name="Tarif" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_PreisDS" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_Sorte" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_PreisStufe" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_PreisSpalte" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="TarifgeberProduktNr" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Schlüssel des Tarifgebers
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Preis" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Preis in kleinster Währungseinheit (z.b.
+						Cent)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PreisStufenbezeichnungKurz" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						optional: abweichende Preisstufenkurzbezeichnung
+						für Anzeige und Druck
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="PreisStufenbezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						optional: abweichende Preisstufenbezeichnung
+						für Anzeige und Druck
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_MwSt" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						optional: abweichende Mehrwertsteuerkennung
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Layout" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						optional: abweichende Layoutdefinition
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_PreisStufeReferenz" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            optional
+            Referenz auf die tatsächlich zu verwendende Preisstufe für 
+              Druck
+              Anzeige
+              Registrierung
+              Gültigkeitsberechnung
+            
+            Verwendung:
+            Wenn eine Tarifverbindung eine ID_Preisstufe x liefert, und die Tarifbestimmungen definieren, dass 
+            für dieses Sorte statt der ID_Preisstufe x ein Fahrschein mit der Preisstufe y verkauft werden soll,
+            wird in ID_PreisStufeReferenz ein Verweis auf Preisstufe y eingetragen.
+          </xs:documentation>
+        </xs:annotation>
+			</xs:element>
+			<xs:element name="GueltigRegel" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="GueltigParam" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Menge der Gültigkeitseinheiten,
+						Interpretation nach GueltigRegel
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="GueltigText" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="GueltigRegelEFS" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						1=KW/KM/KJ (fest), 2=gleitend - nächste Einheit
+						-1, 3=Anzahl Tage/Monate
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="GueltigParamEFS" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						bei GRegel 3: Anzahl Tage/Monate
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="VerkaufbarkeitsRegel" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Verkaufsbarkeitregel
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="VerkaufbarkeitsEinheiten" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Verkaufsbarkeiteinheiten
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<!-- KA -->
+			<xs:element name="plOrgID" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Preislisten Organisationsnummer
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="plNummer" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Preislistennummer
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_ProdOrgID" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Produkt Verantwortlicher, überschreibt, wenn
+						vorhanden, die Angabe KA_ProdOrgID aus der
+						Sorten
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element name="KA_RaeumlicheCodierung" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Art der Codierung der räumlichen Gültigkeit
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_Rabatttyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA Rabatttyp</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_ReferenzEFS" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Referenz EFS (optional: abweichende EFS
+						Struktur)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0">
+			  <xs:annotation>
+			    <xs:appinfo>
+			      
+			    </xs:appinfo>
+			  </xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<!--Netz -->
+	<xs:complexType name="OrtspunkteTG_Type">
+		<xs:annotation>
+			<xs:documentation>
+				tarifgebietspezifische-Attribute der Ortspunkte
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_OrtspunkteTGDS"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_OPTG_Main">
+					<field name="ID_OrtsNummer"/>
+					<field name="ID_OrtsPunktTyp"/>
+					<field name="ID_TarifGebiet"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<schema name="Angebot" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_OrtspunkteTGDS" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Eindeutige Datensatz-ID innerhalb der ID_Zeitraum</xs:documentation></xs:annotation></xs:element>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_OrtsPunktTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Bspw. Betriebshof
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_OrtsNummer" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Bundeseinheitliche HST Nummer
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Ortsbezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Ortsbezeichnung
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OrtsbezeichnungKurz" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Kurzbezeichnung des Orts
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OrtsbezeichnungDruck" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Bezeichnung des Orts für den Ausdruck
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ExtOrtsNummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Tarifgeberspez. Nr., bspw. für Aufdruck
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Tarifpunktbezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Tarifpunktbezeichnung
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TarifpunktbezeichnungKurz" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Kurzbezeichnung des Tarifpuntkes
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="TarifpunktbezeichnungDruck" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Tarifpunktbezeichnung für den Ausdruck
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="OrtspunkteKA_Type">
+		<xs:annotation>
+			<xs:documentation>
+				KA-Attribute der Ortspunkte je KVP-ID
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_OrtspunktKADS"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_OPKA_Main">
+					<field name="ID_OrtsNummer"/>
+					<field name="ID_OrtsPunktTyp"/>
+					<field name="KA_OrtOrgID"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<index name="Idx_OPKA_OrtNummer">
+					<field name="KA_OrtOrgID"/>
+					<field name="KA_OrtNummer"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<schema name="Angebot" nillable="true"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_OrtspunktKADS" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Eindeutige Datensatz-ID innerhalb der ID_Zeitraum</xs:documentation></xs:annotation></xs:element>
+			<xs:element name="ID_OrtsPunktTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Bspw. Betriebshof
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_OrtsNummer" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Bundeseinheitliche HST Nummer
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_OrtOrgID" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="KA_OrtTyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA Ortstyp</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_OrtNummer" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>KA Ortnummer</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_Ortsbezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Ortsbezeichnung
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_Tarifpunktbezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						KA Tarifpunktbezeichnung
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="Ortspunkte_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Haltestellen mit Zonen/Relationscode Zuordnung
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_OrtspunktDS"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_OP_Main">
+					<field name="ID_OrtsNummer"/>
+					<field name="ID_OrtsPunktTyp"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<index name="Idx_OP_IBISnr">
+					<field name="IBISnr"/>
+					<field name="ID_OrtsPunktTyp"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<index name="Idx_OP_RelCode">
+					<field name="ID_RelCode"/>
+					<field name="ID_OrtsPunktTyp"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<index name="Idx_OP_ExtOrtsNummer">
+					<field name="ExtOrtsNummer"/>
+					<field name="ID_OrtsPunktTyp"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<schema name="Angebot" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_OrtspunktDS" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Eindeutige Datensatz-ID innerhalb der ID_Zeitraum</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_OrtsPunktTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Bspw. Betriebshof</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_OrtsNummer" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Bundeseinheitliche HST Nummer
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_RelCode" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="IBISnr" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Bundesland" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Gemeindekennziffer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Bezeichnung des Ortspunktes (z.B. für die Anzeige)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BezeichnungKurz" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Kurzbezeichnung des Ortspunktes (z.B. für zusammengesetzte
+						Via-Information, wenn das Attribut leer ist, wird
+						Bezeichnung verwendet)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BezeichnungDruck" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Bezeichnung des Ortspunktes für den Ausdruck (wenn das
+						Attribut leer ist, wird Bezeichnung verwendet)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ExtOrtsNummer" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Tarifgeberspez. Nr., bspw. für Aufdruck
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Bediengebiet" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="XKoordWgs84" type="tpd:KoordWgs84_Type" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="YKoordWgs84" type="tpd:KoordWgs84_Type" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Fangbereich" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Fangbereich für GPS in Metern. Wenn kein Fangbereich
+						angegeben ist, gilt ein systeminterner Defaultwert
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_OrtsPunktTypRef" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Referenziert einen übergeordneten Ortspunkt - zusammen mit
+						ID_OrtsNummerRef
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_OrtsNummerRef" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Referenziert einen übergeordneten Ortspunkt - zusammen mit
+						ID_OrtsPunktTypRef
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Innenanzeigetext" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0">
+			  <xs:annotation>
+			    <xs:appinfo>
+			      
+			    </xs:appinfo>
+			  </xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Linien_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Linie"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Angebot" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Linie" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Liniennummer</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Weg_Hin" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Linienhauptweg</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Weg_Rueck" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Linienhauptweg Rückrichtung
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Konzessionaer" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Bediengebiet" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Wege_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Fahrtnummer, Kursnummer
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Weg"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Angebot" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Weg" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Eindeutige Nummer des Weges.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Wegpositionen_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Ortsposition innerhalb der Fahrt
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Weg"/>
+					<field name="SortOrder"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_WP_OP">
+					<field name="ID_OrtsPunktTyp"/>
+					<field name="ID_OrtsNummer"/>
+					<field name="ID_Weg"/>
+				</index>
+				<schema name="Angebot" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Weg" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="SortOrder" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_OrtsPunktTyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_OrtsNummer" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Bediengebiet" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Entfernung" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Entfernung vom vorhergehenden Ortspunkt in Metern
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element name="Fangbereich" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						optionaler Fangbereich der Wegposition in Metern für eine
+						GPS Ortung - überschreibt eine entsprechende Angabe bei der
+						Ortspunktdefinition
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Wegpositionenzeit_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Fahr- und Haltezeiten einer Wegposition für verschiedene
+				Fahr-/Haltezeitgruppen
+			</xs:documentation>
+			<xs:appinfo>
+				<schema name="Angebot" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Weg" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						ID_Weg bildet mit SortOrder den Fremdschlüssel zur
+						Wegposition, der sie zugeordnet sind.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SortOrder" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Wegzeittyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Wegzeittyp definiert die Art von Wegzeit, die hier
+						dokumentiert wird: 1=Fahrzeit, 2=Haltezeit.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Zeitgruppe" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Nummer der Haltezeitgruppe bzw. der
+						Fahrzeitgruppe, zu der die angegebene Wegpositionenzeit
+						gehört.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Dauer" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Dauer der Wegpositionszeit in Sekunden.
+						Bei Fahrzeiten ist das die Dauer bis zum Erreichen der nächsten
+						Wegposition,
+						bei Haltezeiten ist das die Aufenthaltsdauer bis zur Abfahrt an
+						dieser Wegposition.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Zielanzeigetext_Type">
+		<xs:annotation>
+			<xs:documentation>Anzeigetexte für die Zielanzeigen (vorne und auf
+				der Seite) des Fahrzeuges.</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Zielanzeigetext"/>
+					<field name="ID_Zielanzeigetyp"/>
+					<field name="Taktnummer"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Netz" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Zielanzeigetext" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+
+			<xs:element name="Taktnummer" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Zielanzeigetyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="IBISZielcode" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Fahreranzeige" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="FronttextOben" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="FronttextUnten" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="SeitetextOben" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="SeitetextUnten" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="Sonderzeichen" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Wagenumlauf_Type">
+		<xs:annotation>
+			<xs:documentation>Wagenumläufe stellen eine Reihe von Fahrten
+				zusammen, die hintereinander abgefahren werden.</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_BetriebsTagesArt"/>
+					<field name="ID_Wagenumlauf"/>
+					<field name="SortOrder"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Angebot" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_BetriebsTagesArt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>ID der Betriebstagesart</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Wagenumlauf" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						eindeutige Nummer des Wagenumlaufes für die angegebene Betriebstagesart
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="SortOrder" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Fahrt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<!--Hilfstabellen -->
+	<xs:complexType name="Sortenklassen_Type">
+		<xs:annotation>
+			<xs:appinfo>
+			    <primekey>
+			      <field name="ID_Sortenklasse"/>
+			      <field name="ID_Zeitraum"/>
+			    </primekey>
+				<schema name="Tarif" nillable="false"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Sortenklasse" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Nummer der Sortenklasse</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+
+	<xs:complexType name="Waehrungen_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+				  <field name="ID_Waehrungscode"/>
+				  <field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarif" nillable="false"/>				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Waehrungscode" type="xs:string" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>ISO-Kennung (dezimal) der Währung -
+						außer EUR=999</xs:documentation>
+					<xs:appinfo>
+						<primekey>
+							<field name="ID_Waehrungscode"/>
+						</primekey>
+					</xs:appinfo>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>ISO-Kurzbezeichnung z.B. EUR, USD, CHF,...
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Updateinfo_Type">
+		<xs:annotation>
+			<xs:documentation>Dokumentation von Updatevorgängen über der zunächst
+				generierten Datenmenge</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="Updatetime"/>
+					<field name="Filename"/>
+				</primekey>
+				<schema name="Basis" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Updatetime" type="tpd:DateTimeCompact" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Zeitpunkt des Updatevorgangs
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Filename" type="xs:string" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Filename des Updatescripts oder Bezeichnung des
+						Updatevorgangs
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Purpose" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Hinweis zum Zweck des Updatevorgangs
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="MwSt_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_MwSt"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarif" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_MwSt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Kennung des Mehrwertsteuersatzes
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="MwStSatz" type="tpd:FLOAT1" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Prozentzahl des Mehrwertsteuersatzes
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Info zum MwSt.-Satz; bspw. ermäßigter Steuersatz etc.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ReferenzExtern" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Dient als Referenz um extern definierte
+						Mehrwertsteuerdatensätze über eine nicht numerische Referenz
+						identifizieren zu können.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="KA_MwSt" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Preisspaltekennungen_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Preisspaltenkennung"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_PspKenn_Psp">
+					<field name="ID_PreisSpalte"/>
+				</index>
+				<schema name="Tarif" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Preisspaltenkennung" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_PreisSpalte" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>1=1. Klasse, 2=2. Klasse,
+						3=Klassenübergang</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="BahnCard" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Tarifarten_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Gruppierungs- (Sorten via SortenTarifarten) und
+				Differenzierungsattribut (Teilrelationen,
+				Preisstufendirektwahlen).
+				Damit lassen sich z.B. eigene
+				Relationen für ganze Gruppen von Fahrscheinensorten vom
+				allgemeinen Fall abtrennen (Bartarif/Zeittarif).
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_TarifArt"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarif" nillable="true"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TarifArt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						0=Allgemein, 1=Bartarif, 2=Zeittarif
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ReferenzExtern" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Relationscodegruppentypen_Type">
+		<xs:annotation>
+			<xs:documentation>
+				bspw. als Magneten für Citytarif
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_RelCodeGruppenTyp"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarif" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_RelCodeGruppenTyp" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>1=Magnet, 2=Startort</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Ortspunkttypen_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_OrtsPunktTyp"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Angebot" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_OrtsPunktTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>1=Haltestelle, 2=Betriebshof, 3=Zone/Wabe
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Zielanzeigetyp_Type">
+		<xs:annotation>
+			<xs:documentation>Anzeigetypen, die unterschiedliche Versorgungsdaten
+				verlangen</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Zielanzeigetyp"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+        <schema name="Netz" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Zielanzeigetyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Inhalt_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Inhaltsversion"/>
+					<field name="Erstellungsdatum"/>
+					<field name="Lieferant"/>
+				</primekey>
+				<schema name="Basis" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Inhaltsversion" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Testdaten" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Erstellungsdatum" type="tpd:DateTimeCompact" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Lieferant" type="xs:string" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Kommentar" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Bearbeitung_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="Bearbeitungsdatum"/>
+					<field name="Lieferant"/>
+				</primekey>
+				<schema name="Basis" nillable="true"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Bearbeitungsdatum" type="tpd:DateTimeCompact" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Lieferant" type="xs:string" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Kommentar" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Geraetetypen_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_GeraeteTyp"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Basis" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_GeraeteTyp" type="xs:string" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>AKxxxx</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Info</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Einsatzarten_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_EinsatzArt"/>
+					<field name="ID_GeraeteTyp"/>
+				</primekey>
+				<schema name="Personal" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_GeraeteTyp" type="xs:string" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>AKxxxx</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_EinsatzArt" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Info</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="TarifrelevantePunkte_Type">
+		<xs:annotation>
+			<xs:documentation>
+				OTP - Orte und tarifrelevante Punkte. Unabhhänig
+				von konkreten
+				Haltestellen bieten tarifrelevante Punkte die
+				Möglichkeit, dem
+				Bediener Reiseziele anzubieten, zu denen einen
+				Verkauf erfolgen
+				soll. Jedem OTP ist genau ein Relationscode
+				zugeordnet, über den
+				Relationen gesucht werden.
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_TarifrelevanterpunktDS"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_OTP_Main">
+					<field name="ID_OTPTyp"/>
+					<field name="ID_Bediengebiet"/>
+					<field name="ID_Zeitraum"/>
+					<field name="Bezeichnung"/>
+					<field name="Rang"/>
+				</index>
+				<index name="Idx_OTP_RelCode">
+					<field name="ID_RelCode"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<schema name="Angebot" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TarifrelevanterpunktDS" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+				  <xs:documentation>Eindeutiger DS-Index innerhalb der ID_Zeitraum</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_RelCode" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_OTPTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Bundesland" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Bediengebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_OrtsPunktTyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_OrtsNummer" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Sortengruppe" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Verweist zusammen mit ID_SortenGruppenTyp,
+						ID_Bediengebiet auf eine Sortengruppe, die mit dieser
+						Zielauswahl direkt verkauft wird (Festpreis, keine Relation)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_SortenGruppenTyp" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>siehe ID_Sortengruppe</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Standortwahl_ID_Bediengebiet" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_OTPTyp_Ref" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Über ID_OTPTyp_Ref und Bezeichnung_Ref kann
+						eine baumartige
+						Auswahlstruktur definiert werden. Blätter und
+						Knoten
+						referenzieren über die beiden Felder explizit und ihre
+						eigenen Felder ID_Zeitraum und ID_Bediengebiet implizit
+						einen Elternknoten. Die Bildung von Referenzbäumen ist
+						optional. SortOrder definiert die Sortierung aller
+						Kindknoten eines Ranges. Innerhalb der gleichen SortOrder
+						werden die Knoten alphabetisch sortiert.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element name="Bezeichnung_Ref" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Rang" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="SortOrder" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Bediengebiete_Type">
+		<xs:annotation>
+			<xs:documentation>Bediengebiete erlauben die Defintion von Sichten
+				auf Auswahlelemente (Tarifrelevante Punkte, Haltestellen, etc.).
+				Damit ist die Möglichkeit zur Filterung von Start/Zielauswahlen
+				in verschiedenen Umfeldern möglich.
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Bediengebiet"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Angebot" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Bediengebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="VerkaufbareTarifgebiete_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Bediengebiet"/>
+					<field name="ID_Zeitraum"/>
+					<field name="ID_TarifGebiet"/>
+				</primekey>
+				<schema name="Angebot" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_Bediengebiet" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Verkaufbarkeit" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>1=Verkaufbar projektspezifische
+						Restriktionen
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="OTPTypen_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_OTPTyp"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Angebot" nillable="false"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_OTPTyp" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+
+	<xs:complexType name="Sortengruppen_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_SortengruppeDS"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_SoGr_Main">
+					<field name="ID_Sortengruppe"/>
+					<field name="ID_SortenGruppenTyp"/>
+					<field name="ID_Bediengebiet"/>
+					<field name="SortOrder"/>
+					<field name="ID_Zeitraum"/>
+					<field name="ID_Sorte"/>
+				</index>
+				<index name="Idx_SoGr_ID_Sorte">
+					<field name="ID_Sorte"/>
+					<field name="ID_Zeitraum"/>
+				</index>
+				<schema name="Tarif" nillable="true"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_SortengruppeDS" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_Sortengruppe" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_SortenGruppenTyp" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_Bediengebiet" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="SortOrder" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Info</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element name="TarifInfo" type="tpd:blobString" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Sorte" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_PreisStufe" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>ID_PreisStufe ist optional. Wenn die
+						Preisstufe angegeben ist, wird der Produkt als Festpreis
+						verkauft. Ansonsten muss die Preisstufe aufgrund weiterer
+						Einschränkungen (z.b. Auswahl einer Relation) ermittelt bzw.
+						festgelegt werden.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0">
+			  <xs:annotation>
+			    <xs:appinfo>
+			      
+			    </xs:appinfo>
+			  </xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="VersionStruktur_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<schema name="Basis" nillable="false"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="VersionMajor" type="tpd:INT4" default="2" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="VersionMinor" type="tpd:INT4" default="46" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Status" type="tpd:VersionStatus_Type" default="in Arbeit" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Aenderungsdatum" type="tpd:DateCompact" default="2020-04-28" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="Aenderungsautor" type="xs:string" default="hneubauer(kt)" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Fahrten_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Fahrt"/>
+					<field name="ID_BetriebsTagesArt"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<index name="Idx_Fahrt_Linie">
+					<field name="ID_Linie"/>
+				</index>
+				<index name="Idx_Fahrt_Weg">
+					<field name="ID_Weg"/>
+				</index>
+				<schema name="Angebot" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_BetriebsTagesArt" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Betriebstagesart, zu der diese Fahrt definiert ist.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Fahrt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						eindeutige Nummer des Fahrt für die angegebene
+						Betriebstagesart
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Linie" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_Zielanzeigetext" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="Richtung" type="tpd:Richtungen_Type" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_Weg" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Wenn keine ID_Weg angegeben ist, wird der zur Richtung
+						passende Weg von der Linie verwendet.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Abfahrt" type="tpd:Betriebszeit_Type" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Fahrzeitgruppe" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="Haltezeitgruppe" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Sortenattributgruppen_Type">
+		<xs:annotation>
+			<xs:documentation>
+				In dieser Tabelle werden die verschiedenen Werte
+				der Attributgruppen aufgelistet und nach
+				tarifarischer Bedeutung
+				gruppiert
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_AttributKlasse"/>
+					<field name="ID_Zeitraum"/>
+					<field name="ID_Bediengebiet"/>
+					<field name="ID_AttributGruppe"/>
+					<field name="AttributText"/>
+				</primekey>
+				<schema name="Tarif" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_AttributKlasse" type="tpd:ID_SortenAttributKlasse_Type" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						AttributKlasse (1=Komfortklasse,
+						2=Rabattklasse,
+						3=Fahrgasttyp, ...)
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ID_Bediengebiet" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_AttributGruppe" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Attributgruppe innerhalb einer
+						Attributklasse Mit der
+						Gruppierung können mehrere Attribute,
+						auf gemeinsame
+						Steuerungselemente (z.B. Buttons) bezogen
+						werden.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element name="AttributText" type="xs:string" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Bundeslaender_Type">
+		<xs:annotation>
+			<xs:documentation>Ortspunkte werden einem Bundesland zugeordnet
+				(direkt oder ggf. auch indirekt)
+			</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Bundesland"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Basis" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Bundesland" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Name des Bundeslandes</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Feiertage_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="Datum"/>
+					<field name="ID_Bundesland"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Basis" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Bundesland" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Datum" type="tpd:DateCompact" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:complexType name="Unternehmen_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Unternehmen"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Basis" nillable="true"/>
+				
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="ID_Unternehmen" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+			<xs:element name="BezeichnungKurz" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="BezeichnungLang" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="Mandant" type="xs:boolean" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+					True, wenn das Unternehmen als Mandant im System geführt
+					wird.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Zusatzinfo" type="tpd:blobString" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ReferenzExtern" nillable="true" maxOccurs="1" minOccurs="0" type="xs:string">
+				<xs:annotation>
+					<xs:documentation>
+					Dient als Referenz um Unternehmen über eine nicht numerische
+					Referenz ggf. auch bezogen auf Drittsysteme identifizieren
+					zu können.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+
+  <xs:complexType name="Beauftragungen_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <primekey>
+          <field name="ID_Beauftragung"/>
+          <field name="ID_Zeitraum"/>
+        </primekey>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Beauftragung" type="tpd:INT4" nillable="false" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" maxOccurs="1" minOccurs="0" nillable="true">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um Beauftragsungstype über eine nicht numerische
+            Referenz ggf. auch bezogen auf Drittsysteme identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="UnternehmensBeauftragungen_Type">
+    <xs:annotation>
+      <xs:documentation>Definiert ein Auftragsverhältnis zwischen zwei in Unternehmen_Type definierten Unternehmen.
+      Das gleiche Unternehmen das im einen Fall als Auftraggeber auftritt, kann gleichzeitig in einem anderen 
+      Fall als Auftragnehmer fungieren.
+      </xs:documentation>
+      <xs:appinfo>
+        <primekey>
+          <field name="ID_UnternehmenAuftraggeber"/>
+          <field name="ID_UnternehmenAuftragnehmer"/>
+          <field name="ID_Beauftragung"/>
+          <field name="ID_Zeitraum"/>
+        </primekey>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_UnternehmenAuftraggeber" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_UnternehmenAuftragnehmer" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Beauftragung" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+
+      <xs:element name="Information" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Optionale Information zur Auftraggeber/-nehmer Verbindung</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungLang" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Mandant" type="xs:boolean" maxOccurs="1" minOccurs="0" nillable="true">
+        <xs:annotation>
+          <xs:documentation>
+            True, wenn das Unternehmen als Mandant im System geführt
+            wird.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" maxOccurs="1" minOccurs="0" nillable="true">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um Unternehmen über eine nicht numerische
+            Referenz ggf. auch bezogen auf Drittsysteme identifizieren
+            zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Zusatzinfo" type="tpd:blobString" nillable="true" minOccurs="0" maxOccurs="1"/>
+
+    </xs:sequence>
+  </xs:complexType>
+
+	<xs:complexType name="Preisquellen_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Preisquelle"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarif" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_Preisquelle" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Bezeichnung" type="xs:string" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Bezeichnung der Preisquelle z.B.
+						NE-Blatt-Nummer
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttribut" type="tpd:DynAttribut_Subtype" nillable="false" maxOccurs="unbounded" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<!--Ende Tabellen -->
+
+	<!--Allgemein -->
+	<xs:element name="Inhalt" type="tpd:Inhalt_Type" nillable="true"/>
+	<xs:element name="Bearbeitung" type="tpd:Bearbeitung_Type" nillable="true"/>
+	<xs:element name="Bundeslaender" type="tpd:Bundeslaender_Type" nillable="true"/>
+	<xs:element name="Tarifgebiete" type="tpd:Tarifgebiete_Type" nillable="true"/>
+	<xs:element name="Tarifpunkte" type="tpd:Tarifpunkte_Type" nillable="true"/>
+	<xs:element name="TarifpunktmengeElemente" type="tpd:TarifpunktmengeElemente_Type" nillable="true"/>
+	<xs:element name="Tarifpunktmengen" type="tpd:Tarifpunktmengen_Type" nillable="true"/>
+	<xs:element name="Zeitraeume" type="tpd:Zeitraeume_Type" nillable="true"/>
+	<xs:element name="ZeitraumOptionen" type="tpd:ZeitraumOptionen_Type" nillable="true"/>
+	<xs:element name="Kalender" type="tpd:Kalender_Type" nillable="true"/>
+	<xs:element name="Tagesarten" type="tpd:Tagesarten_Type" nillable="true"/>
+	<xs:element name="Tagesmerkmale" type="tpd:Tagesmerkmale_Type" nillable="true"/>
+	<xs:element name="TagesmerkmalElemente" type="tpd:TagesmerkmalElemente_Type" nillable="true"/>
+	<xs:element name="TagesartMerkmalElemente" type="tpd:TagesartMerkmalElemente_Type" nillable="true"/>
+	<xs:element name="IdentobjektTypen" type="tpd:IdentobjektTypen_Type" nillable="true"/>
+	<xs:element name="Identobjekte" type="tpd:Identobjekte_Type" nillable="true"/>
+	<xs:element name="PersonalIdentobjekte" type="tpd:PersonalIdentobjekte_Type" nillable="true"/>
+	<xs:element name="Personal" type="tpd:Personal_Type" nillable="true"/>
+	<xs:element name="Personaleinsatz" type="tpd:Personaleinsatz_Type" nillable="true"/>
+	<xs:element name="Standort" type="tpd:Standort_Type" nillable="true"/>
+	<xs:element name="Geraet" type="tpd:Geraet_Type" nillable="true"/>
+	<xs:element name="GeraetEinsatztypen" type="tpd:GeraetEinsatztypen_Type" nillable="true"/>
+	<xs:element name="Feiertage" type="tpd:Feiertage_Type" nillable="true"/>
+	<xs:element name="Unternehmen" type="tpd:Unternehmen_Type" nillable="true"/>
+
+
+	<!--Relationen -->
+	<xs:element name="Interpretationen" type="tpd:Interpretationen_Type" nillable="true"/>
+	<xs:element name="RaeumlicheGueltigkeit" type="tpd:RaeumlicheGueltigkeit_Type" nillable="true"/>
+	<xs:element name="Relationscodes" type="tpd:Relationscodes_Type" nillable="true"/>
+	<xs:element name="Relationscodegruppen" type="tpd:Relationscodegruppen_Type" nillable="true"/>
+	<xs:element name="Relationen" type="tpd:Relationen_Type" nillable="true"/>
+	<xs:element name="Vias" type="tpd:Vias_Type" nillable="true"/>
+	<xs:element name="TeilRelationen" type="tpd:TeilRelationen_Type" nillable="true"/>
+	<xs:element name="Nachbarhaltestellen" type="tpd:Nachbarhaltestellen_Type" nillable="true"/>
+	<xs:element name="PreisstufenDirektwahl" type="tpd:PreisstufenDirektwahl_Type" nillable="true"/>
+
+	<!--Produkte -->
+	<xs:element name="Preisspalten" type="tpd:Preisspalten_Type" nillable="true"/>
+	<xs:element name="Preisstufen" type="tpd:Preisstufen_Type" nillable="true"/>
+	<xs:element name="SortenTarifarten" type="tpd:SortenTarifarten_Type" nillable="true"/>
+	<xs:element name="Sorten" type="tpd:Sorten_Type" nillable="true"/>
+	<xs:element name="Zusatzsorten" type="tpd:Zusatzsorten_Type" nillable="true"/>
+	<xs:element name="Preise" type="tpd:Preise_Type" nillable="true"/>
+
+
+	<!--Netz -->
+	<xs:element name="OrtspunkteTG" type="tpd:OrtspunkteTG_Type" nillable="true"/>
+	<xs:element name="OrtspunkteKA" type="tpd:OrtspunkteKA_Type" nillable="true"/>
+	<xs:element name="Ortspunkte" type="tpd:Ortspunkte_Type" nillable="true"/>
+	<xs:element name="TarifrelevantePunkte" type="tpd:TarifrelevantePunkte_Type"/>
+	<xs:element name="Bediengebiete" type="tpd:Bediengebiete_Type"/>
+	<xs:element name="VerkaufbareTarifgebiete" type="tpd:VerkaufbareTarifgebiete_Type"/>
+	<xs:element name="Linien" type="tpd:Linien_Type" nillable="true"/>
+	<xs:element name="Wagenumlauf" type="tpd:Wagenumlauf_Type" nillable="true"/>
+	<xs:element name="Wege" type="tpd:Wege_Type" nillable="true"/>
+	<xs:element name="Wegpositionen" type="tpd:Wegpositionen_Type" nillable="true"/>
+	<xs:element name="Wegpositionenzeit" type="tpd:Wegpositionenzeit_Type" nillable="true"/>
+	<xs:element name="Fahrten" type="tpd:Fahrten_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Fahrten verweisen auf Linien und geben an, ob
+				sie die
+				Hin- oder Rückrichtung abfahren. Die ID_Fahrt kann im
+				Bahnverkehr auch als Zugnummer interpretiert werden.
+			</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+
+	<!--Hilfs -->
+	<xs:element name="Sortenklassen" type="tpd:Sortenklassen_Type" nillable="true"/>
+	<xs:element name="Waehrungen" type="tpd:Waehrungen_Type" nillable="true"/>
+	<xs:element name="MwSt" type="tpd:MwSt_Type" nillable="true"/>
+	<xs:element name="Preisspaltekennungen" type="tpd:Preisspaltekennungen_Type" nillable="true"/>
+	<xs:element name="Tarifarten" type="tpd:Tarifarten_Type" nillable="true"/>
+	<xs:element name="Preisquellen" type="tpd:Preisquellen_Type" nillable="true"/>
+	<xs:element name="Relationscodegruppentypen" type="tpd:Relationscodegruppentypen_Type" nillable="true"/>
+	<xs:element name="Ortspunkttypen" type="tpd:Ortspunkttypen_Type" nillable="true"/>
+	<xs:element name="Geraetetypen" type="tpd:Geraetetypen_Type" nillable="true"/>
+	<xs:element name="Einsatzarten" type="tpd:Einsatzarten_Type" nillable="true"/>
+	<xs:element name="OTPTypen" type="tpd:OTPTypen_Type"/>
+	<xs:element name="Sortengruppen" type="tpd:Sortengruppen_Type"/>
+	<xs:element name="VersionStruktur" type="tpd:VersionStruktur_Type"/>
+	<xs:element name="Sortenattributgruppen" type="tpd:Sortenattributgruppen_Type"/>
+	<xs:element name="Zielanzeigetext" type="tpd:Zielanzeigetext_Type"/>
+	<xs:element name="Zielanzeigetyp" type="tpd:Zielanzeigetyp_Type"/>
+
+	<!-- INTERN! NUR FÜR IMPORT VON TARIFDATEN -->
+	<xs:complexType name="TarifobjektTarifpunkte_Type">
+		<xs:annotation>
+			<xs:appinfo>
+				<primekey>
+					<field name="TO_Rang"/>
+					<field name="TO_ID_Bediengebiet"/>
+					<field name="TO_ID_OTPTyp"/>
+					<field name="TO_Bezeichnung"/>
+					<field name="TO_ID_TarifPunktTyp"/>
+					<field name="TO_ID_TarifPunkt"/>
+					<field name="TO_ID_TarifGebiet"/>
+					<field name="TO_ID_OrtsNummer"/>
+					<field name="TO_ID_OrtsPunktTyp"/>
+					<field name="TO_ID_Sorte"/>
+					<field name="Tarifobjekttyp"/>
+					<field name="ID_Zeitraum"/>
+				</primekey>
+				<schema name="Tarifimport" nillable="true"/>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Deaktiviert" type="xs:boolean" nillable="true" minOccurs="0" maxOccurs="1"/>
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="Tarifobjekttyp" type="tpd:Tarifobjekttyp_Type" nillable="false" maxOccurs="1" minOccurs="1"/>
+
+			<xs:element name="TO_ID_OrtsPunktTyp" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="TO_ID_OrtsNummer" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Für Tarifobjekte (TO) "Ortspunkte" bilden TO_ID_OrtsPunktTyp und
+						TO_ID_OrtsNummer den Schlüssel zum
+						referenzierten Ortspunkt.
+
+						Für Tarifobjekte (TO) "OrtspunkteTG" bilden TO_ID_TarifGebiet,
+						TO_ID_OrtsPunktTyp und TO_ID_OrtsNummer den Schlüssel zum
+						referenzierten Ortspunkt.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element name="TO_ID_TarifGebiet" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="TO_ID_TarifPunkt" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="TO_ID_TarifPunktTyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Für Tarifobjekte (TO) "Tarifpunkte" bilden TO_ID_TarifGebiet,
+						TO_ID_TarifPunkt und TO_ID_TarifPunktTyp
+						den Schlüssel zum referenzierten Ortspunkt.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element name="TO_ID_Sorte" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Für Tarifobjekte (TO) "Sorte" bildet TO_ID_Sorte
+						den Schlüssel zur referenzierten Sorte.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element name="TO_Bezeichnung" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="TO_ID_OTPTyp" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="TO_ID_Bediengebiet" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="TO_Rang" type="tpd:INT4" nillable="true" maxOccurs="1" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>
+						Für Tarifobjekte (TO) "TarifrelevantePunkte" bilden TO_Bezeichnung,
+						TO_ID_OTPTyp, TO_ID_Bediengebiet und TO_Rang
+						den Schlüssel zum referenzierten Ortspunkt.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+
+			<xs:element name="ID_TarifGebiet" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_TarifPunkt" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1"/>
+			<xs:element name="ID_TarifPunktTyp" type="tpd:INT4" nillable="true" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:element name="TarifobjektTarifpunkte" type="tpd:TarifobjektTarifpunkte_Type"/>
+
+	<xs:element name="Updateinfo" type="tpd:Updateinfo_Type"/>
+
+	<!--Wurzel -->
+	<xs:element name="OePVTarifDB" nillable="false" type="tpd:OePVTarifDB_Type"/>
+
+	<xs:complexType name="OePVTarifDB_Type">
+		<xs:choice maxOccurs="unbounded">
+			<xs:element ref="tpd:Bediengebiete"/>
+			<xs:element ref="tpd:Bearbeitung"/>
+			<xs:element ref="tpd:Bundeslaender"/>
+			<xs:element ref="tpd:Einsatzarten"/>
+			<xs:element ref="tpd:Fahrten"/>
+			<xs:element ref="tpd:Feiertage"/>
+			<xs:element ref="tpd:Geraet"/>
+			<xs:element ref="tpd:GeraetEinsatztypen"/>
+			<xs:element ref="tpd:Geraetetypen"/>
+			<xs:element ref="tpd:IdentobjektTypen"/>
+			<xs:element ref="tpd:Identobjekte"/>
+			<xs:element ref="tpd:Inhalt"/>
+			<xs:element ref="tpd:Interpretationen"/>
+			<xs:element ref="tpd:Kalender"/>
+			<xs:element ref="tpd:Linien"/>
+			<xs:element ref="tpd:MwSt"/>
+			<xs:element ref="tpd:Nachbarhaltestellen"/>
+			<xs:element ref="tpd:Ortspunkte"/>
+			<xs:element ref="tpd:OrtspunkteKA"/>
+			<xs:element ref="tpd:OrtspunkteTG"/>
+			<xs:element ref="tpd:Ortspunkttypen"/>
+			<xs:element ref="tpd:OTPTypen"/>
+			<xs:element ref="tpd:Personal"/>
+			<xs:element ref="tpd:PersonalIdentobjekte"/>
+			<xs:element ref="tpd:Personaleinsatz"/>
+			<xs:element ref="tpd:Preise"/>
+			<xs:element ref="tpd:Preisquellen"/>
+			<xs:element ref="tpd:Preisspaltekennungen"/>
+			<xs:element ref="tpd:Preisspalten"/>
+			<xs:element ref="tpd:Preisstufen"/>
+			<xs:element ref="tpd:PreisstufenDirektwahl"/>
+			<xs:element ref="tpd:RaeumlicheGueltigkeit"/>
+			<xs:element ref="tpd:Relationen"/>
+			<xs:element ref="tpd:Relationscodegruppen"/>
+			<xs:element ref="tpd:Relationscodegruppentypen"/>
+			<xs:element ref="tpd:Relationscodes"/>
+			<xs:element ref="tpd:Sorten"/>
+			<xs:element ref="tpd:Sortenattributgruppen"/>
+			<xs:element ref="tpd:Sortengruppen"/>
+			<xs:element ref="tpd:Sortenklassen"/>
+			<xs:element ref="tpd:SortenTarifarten"/>
+			<xs:element ref="tpd:Standort"/>
+			<xs:element ref="tpd:Tagesarten"/>
+			<xs:element ref="tpd:Tagesmerkmale"/>
+			<xs:element ref="tpd:TagesmerkmalElemente"/>
+			<xs:element ref="tpd:TagesartMerkmalElemente"/>			
+			<xs:element ref="tpd:Tarifarten"/>
+			<xs:element ref="tpd:Tarifgebiete"/>
+			<xs:element ref="tpd:Tarifpunkte"/>
+			<xs:element ref="tpd:TarifpunktmengeElemente"/>
+			<xs:element ref="tpd:Tarifpunktmengen"/>
+			<xs:element ref="tpd:TarifrelevantePunkte"/>
+			<xs:element ref="tpd:TeilRelationen"/>
+			<xs:element ref="tpd:Unternehmen"/>
+			<xs:element ref="tpd:Updateinfo"/>
+			<xs:element ref="tpd:VerkaufbareTarifgebiete"/>
+			<xs:element ref="tpd:VersionStruktur"/>
+			<xs:element ref="tpd:Vias"/>
+			<xs:element ref="tpd:Waehrungen"/>
+			<xs:element ref="tpd:Wagenumlauf"/>
+			<xs:element ref="tpd:Wege"/>
+			<xs:element ref="tpd:Wegpositionen"/>
+			<xs:element ref="tpd:Wegpositionenzeit"/>
+			<xs:element ref="tpd:Zeitraeume"/>
+			<xs:element ref="tpd:ZeitraumOptionen"/>
+			<xs:element ref="tpd:Zielanzeigetext"/>
+			<xs:element ref="tpd:Zielanzeigetyp"/>
+			<xs:element ref="tpd:Zusatzsorten"/>
+
+			<xs:element ref="tpd:TarifobjektTarifpunkte"/>
+		</xs:choice>
+	</xs:complexType>
+
+	<xs:complexType name="DynAttributDef_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Definition der dynamischen Attribute, die in dieser
+				Datenmenge verwendet werden.
+
+				Dynamische Attribute ergänzen einen Datentyp um weitere
+				Eigenschaften. Jedem Datensatz kann für seinen
+				eindeutigen Datensatzschlüssel (ID_[Typname]
+				, z.B. ID_Sorte), der Tabellennummer und der ID
+				einer dynamischen Attribut-Definition ein konkreter
+				Wert für diese Eigenschaft hinterlegt werden.
+			
+Da die AttributDef-Struktur ausschließlich der Interpretation der Daten innerhalb der abgeschlossenen Datenlieferung dient, benötigt sie weder eine deaktiviert Kennung noch eine Referenz auf einen spezifischen Zeitraum innerhalb der Datenmenge.</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_DynAttributDef"/>
+				</primekey>
+				<schema name="Basis" nillable="true"/>
+                
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="ID_DynAttributDef" type="xs:integer" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Referenznummer der dynamischen Attributdefinition. 
+Die Nummer hat nur innerhalb der Datenmenge eine Bedeutung und kann nicht als persistent vorausgesetzt werden.</xs:documentation>
+                  <xs:appinfo>
+                                        
+                  </xs:appinfo>
+				</xs:annotation></xs:element>
+			<xs:element name="Name" type="xs:string" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>
+						Interner Name des dynamischen Attributs. Die möglichen Namen dynamischer Attribute werden bei krauth technology zentral verwaltet. Dabei werden, wenn vorhanden, die in der offen Husst-Schnittstelle abgestimmten Definitionen einbezogen.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="DynAttributTyp" type="tpd:DynAttributTyp_Type" nillable="false" maxOccurs="1" minOccurs="1">
+                <xs:annotation>
+                	<xs:documentation>Der Datentyp der konkreten Daten die unter der ID_DynAttributDef in der Datenmenge DynAttribut_Type im Feld Wert als String-Information abgelegt ist.
+</xs:documentation>
+                </xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:simpleType name="DynAttributTyp_Type">
+		<xs:annotation>
+			<xs:documentation>
+				Die Werte eines dynamischen Attributes werden als String
+				abgelegt. Wie dieser zu verstehen ist, wird durch den
+				DynAttributTyp definiert.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="int">
+			  <xs:annotation>
+			    <xs:documentation>vorzeichenbehaftete Ganzzahl</xs:documentation>
+			  </xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bool">
+			  <xs:annotation>
+			    <xs:documentation>logischer Wert, Wertebereich „0“ für false oder „1“ für true</xs:documentation>
+			  </xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="string">
+			  <xs:annotation>
+			    <xs:documentation>Zeichenkette</xs:documentation>
+			  </xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="datetime">
+			  <xs:annotation>
+			    <xs:documentation>Zeitpunkt (Datum/Uhrzeit) nach ISO8601 - (Beispiel: 2014-06-10T07:46+02:00, eine Angabe ohne die Abweichung von der UTC-Zeit ist auch zulässig)</xs:documentation>
+			  </xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hex">
+			  <xs:annotation>
+			    <xs:documentation>hexadezimal codierter Datenstring - zulässige Zeichen: ‚0‘-‘9‘, ‚a‘-‚f‘, ‚A‘-‚F‘. Niederwertiges Byte zuerst, höherwertiges Halb-Byte zuerst.</xs:documentation>
+			  </xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="id_sprachtext">
+			  <xs:annotation>
+			    <xs:documentation>vorzeichenlose Ganzzahl, Verweis auf ID_Sprachtext in der Tabelle Sprachtexte, einen möglicherweise mehrsprachig hinterlegten Text </xs:documentation>
+			  </xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+
+    <xs:complexType name="DynAttributWert_Type">
+    	<xs:annotation>
+    		<xs:documentation>Die Tabelle enthält den Wert eines dynamischen Attributs.
+
+Die Werte der dynamischen Attribute sind an die ID eines Datensatzes und damit auch an die ID eines konkreten Zeitraumes gekoppelt.
+Deshalb wird die Eigenschaft ID_Zeitraum benötigt. Bezieht sich ein dynamisches Attribut auf eine Tabellennummer, deren Struktur selbst keine ID_Zeitraum Eigenschaft besitzt (z.B. Inhalt_Type), dann bleibt ID_Zeitraum leer.
+
+Anders verhält es sich mit der Deaktiviert Eigenschaft. Diese bezieht sich explizit auf den gesamten Datensatz einer Datenstruktur. Formal wäre dies für die  DynAttributWert Tabelle verwendbar. Allerdings bildet ein Eintrag in der DynAttributWert Tabelle nur ein Attribut innerhalb eines Datensatzes einer anderen Struktur ab. Diese andere Struktur besitzt den Deaktiviert Mechanismus für ihren Datensatz und damit auch für alle dynamischen Attribute, die an diesem Datensatz hängen.</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Zeitraum"/>
+					<field name="ID_DynAttributDef"/>
+					<field name="Tabellennummer"/>
+					<field name="ID_DatensatzRef"/>
+				</primekey>
+				<schema name="Basis" nillable="true"/>
+                
+			</xs:appinfo>
+    	</xs:annotation>
+    	<xs:sequence>
+
+			<xs:element name="ID_Zeitraum" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="0"/>
+			<xs:element name="ID_DynAttributDef" type="xs:integer" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Referenznummer der dynamischen Attributdefinition. 
+Die Nummer hat nur innerhalb der Datenmenge eine Bedeutung und kann nicht als persistent vorausgesetzt werden.</xs:documentation>
+				</xs:annotation>
+				</xs:element>
+			<xs:element name="Tabellennummer" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Eindeutige Nummer der referenzierten Datenstruktur.
+Neben dem eindeutigen Namen jedes Datentyps (z.B. Tarifgebiet für Tarifgebiet_Type) der aus dem Typnamen regelbasiert abgeleitet wird, erhält jeder Typ eine eindeutige Tabellennummer. 
+Damit muss nicht bei jeder Datenmenge eine numerische ID für jeden Datentyp abgelegt werden. Andererseits kann bei Referenzen wie DynAttributWert die Tabellennummer viel effizienter als Schlüsselwert verwendet werden, als ein entsprechender Name.
+</xs:documentation>
+				</xs:annotation></xs:element>
+			<xs:element name="ID_DatensatzRef" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+				<xs:annotation>
+					<xs:documentation>Eindeutiger Datensatzschlüssel (ID_[Typname]) des Datensatzes, für den dieses dynamische Attribut definiert ist.
+Der Datensatz ist in der Datenstruktur zu finden, die mit Tabellennummer eindeutig beschrieben ist und ist zusammen mit ID_Zeitraum eindeutig zu ermitteln.
+
+Warnung!
+Datenstrukturen, die keine eindeutige Datensatz-ID mitführen, können keine dynamischen Attribute haben (z.B. Teilrelationen_Type). Zuvor müssten diese Strukturen um ein ID_[Typname])-Feld erweitert werden.</xs:documentation>
+				</xs:annotation></xs:element>
+			<xs:element name="Wert" type="tpd:blobString" nillable="false" maxOccurs="1" minOccurs="0"/>
+		</xs:sequence>		
+    </xs:complexType>
+
+    <xs:complexType name="Sprachtexte_Type">
+    	<xs:annotation>
+    		<xs:documentation>
+    			Für sprachalternative Texte wird statt ihres Textes eine
+    			ID_Sprachtext als Verweis auf die neue Tabelle
+    			Sprachtexte hinterlegt. Über ID_Sprachtext und der genau
+    			zwei Zeichen langen Sprachkennung kann dann der Text in
+    			der Tabelle Sprachtexte ermittelt werden.
+
+    			Sprachtexte_Type bietet die Möglichkeit, identische Text-Bundle über die gleiche Menge an Sprachkennungen nur einmal in der Datenbank abzulegen und damit das Datenvolumen der Gesamtdatenmenge zu reduzieren. Würde der eigentliche Text selbst noch über eine weitere Referenzstufe sprach- und bedeutungslos in einer Texttabelle hinterlegt, wäre die Einsparung vermutlich einfacher zu realisieren und in der Summer vermutlich größer.
+
+    			Sprachtexte sind innerhalb des Datenpaketes
+    			allgemeingültig definiert und sind nicht über eine
+    			ID_Zeitraum-Eigenschaft versioniert. Ihre IDs sind nicht
+    			persistent denn sie haben nur innerhalb des Datenpaketes
+    			eine referenzierende Bedeutung.
+    		</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="ID_Sprachtext"/>
+					<field name="Lang"/>
+				</primekey>
+				<schema name="Basis" nillable="true"/>
+			</xs:appinfo>
+    	</xs:annotation>
+    	<xs:sequence>
+    		<xs:element name="ID_Sprachtext" type="xs:string" nillable="false" maxOccurs="1" minOccurs="1">
+                <xs:annotation>
+                	<xs:documentation>Eindeutiger Schlüssel für den logischen Inhalt des Textes der unter dieser Nummer ggf. in verschiedenen Sprachen abgelegt ist.</xs:documentation></xs:annotation>
+    		</xs:element>
+    		<xs:element name="Lang" type="tpd:Lang_Type" nillable="false" maxOccurs="1" minOccurs="1">
+                <xs:annotation>
+                	<xs:documentation>Sprache, für die der Text abgelegt ist.</xs:documentation>
+                </xs:annotation>
+    		</xs:element>
+    		<xs:element name="Text" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0"/>
+    	</xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="Tabelleninfo_Type">
+    	<xs:annotation>
+    		<xs:documentation>Erweitertert die XML-Sturktur um Informationen über die Abbildung der Daten in ein relationales Datenmodell.
+Im Wesentlichen dokumentiert die Struktur zur Zeit die fest definierte Beziehung zwischen dem Tabellen-Namen und der persistenten und eindeutigen numerischen Abbildung als Tabellennummer.
+Außerdem stellt sie den Bezug zum Namen der Xml-Datenstruktur her. 
+Falls künftig noch weitere Strukturinformationen benötigt werden, ist an die Erweiterung des Tabelleninfo_Type zu denken.
+
+Damit wird die in &lt;xs:annotation&gt;&lt;appinfo&gt;&lt;tablenumber&gt;... definierte Tabellennummer für nachfolgende Prozesse in jeder Datenmenge hinterlegt.
+
+Die numerische Abbildung einer Struktur wird als Schlüsselelement für den Zugriff auf Datenstrukturen benötigt, deren Elemente sich auf mehrere Elternstrukturen beziehen können. 
+Damit wird es möglichen, diese Beziehung in relationen DBMS performant implementieren zu können. Wegen der spezifischen Verwendung für relationen DBMS wird bewusst der Begriff Tabellennummer verwendet, der ansonsten in der XML-Repräsentation der Daten als Fremdkörper wirkt. 
+Beispiel für die Verwendung ist der DynAttributWert_Type bei dem die Tabellennummer als Attribut im Primärschlüssel der Struktur vorkommt. 
+
+Tabellennummern_Type ist eine Metainformationsstruktur.
+Für die XML-Repräsentanz der Daten spielt sie keine Rolle und muss dort auch nicht eingetragen werden. In der XML-Dartstellung werden die referenzierten Daten nicht getrennt von ihrer Hauptinformation abgelegt sondern bilden noch eine Einheit. 
+Für die Umwandlung in eine DB-Struktur, die diese Tabellennummern benutzt, ist dagegen zwingend vorgeschrieben, mindestens die Tabellennummern zu dokumentieren, die in den Daten verwendet werden. Die komplette Auflistung der Tabellenmmnern einer Struktur wird für DB-Repräsentationen empfohlen. 
+</xs:documentation>
+			<xs:appinfo>
+				<primekey>
+					<field name="Tabellennummer"/>
+				</primekey>
+				<index name="Idx_Tabinfoname">
+					<field name="Tabellenname"/>
+				</index>
+				<schema name="Basis" nillable="true"/>
+                
+			</xs:appinfo>
+    	</xs:annotation>
+    	<xs:sequence>
+    		<xs:element name="Tabellenname" type="xs:string" nillable="false" maxOccurs="1" minOccurs="1">
+    			<xs:annotation>
+    				<xs:documentation>
+    					Name der Tabelle in einer relationen DB
+    					Abbildung dieser Datenstruktur. Zum Beispiel
+    					'Sorten' für die Elemente der Sorten_Type
+    					Struktur. Er entspricht dem Xml-Attribut "name" der Element-Definition der
+    					Struktur in der XML-Datenmenge. Zum Beispiel
+    					&lt;xs:element name="Sorten"
+    					type="tpd:Sorten_Type" nillable="true" /&gt;
+    					oder auch
+    					&lt;xs:element name="SortenTarifarten"
+    					type="tpd:SortenTarifarten_Type" nillable="true" /&gt;
+
+    					Die Schreibweise des Names entspricht dem Elementname, der in der Xml-Datenmenge verwendet wird.
+    				</xs:documentation>
+    			</xs:annotation>
+    		</xs:element>
+    		<xs:element name="Tabellennummer" type="tpd:INT4" nillable="false" maxOccurs="1" minOccurs="1">
+    			<xs:annotation>
+    				<xs:documentation>
+    					Persistente und eindeutigen numerische
+    					Abbildung. Die Tabellennnummer wird in dieser
+    					Struktur als
+    					&lt;xs:annotation&gt;&lt;appinfo&gt;&lt;tablenumber
+    					hinterlegt und gilt als Teil der
+    					Strukturdefinition.
+    				</xs:documentation>
+    			</xs:annotation>
+    		</xs:element>
+
+    		<xs:element name="Strukturname" type="xs:string" nillable="true" maxOccurs="1" minOccurs="0">
+    			<xs:annotation>
+    				<xs:documentation>Name der Xml-Datenstruktur, die von dieser Tabelle abgebildet wird.</xs:documentation>
+    			</xs:annotation></xs:element>
+    	</xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="DynAttribut_Subtype">
+    	<xs:annotation>
+    		<xs:documentation>
+    			Der Subtyp DynAttribut_Subtype dient der Definition von
+    			dynamischen Attributen als mögliche Erweiterung für die
+    			Xml-Darstellung der Daten. Der Subtyp wird nicht 1:1 für
+    			eine Abbildung auf ein relationales Datenbankmodell
+    			verwendet.
+    		</xs:documentation>
+    	</xs:annotation>
+    	<xs:sequence>
+    		<xs:element name="Name" type="xs:string" maxOccurs="1" minOccurs="1"/>
+    		<xs:element name="Wert" type="tpd:DynAttributWert_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    	</xs:sequence>
+    	<xs:attribute name="dtyp" type="tpd:DynAttributTyp_Type"/>
+    </xs:complexType>
+    
+    <xs:complexType name="DynAttributWert_Subtype">
+      <xs:simpleContent>
+        <xs:extension base="tpd:blobString">
+          <xs:attribute name="lang" type="tpd:Lang_Type"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+
+</xs:schema>


### PR DESCRIPTION
HUSST_Versorgungsdaten_2_46.xsd (in Arbeit) aufgesetzt
inhaltlich unverändert zur HUSST_Versorgungsdaten_2_45.xsd.

Damit können im Folgenden die Veränderungen der 2_46 gegenüber der 2_45
über Diff besser nachvollzogen werden.