### PR TITLE
Version 2.21 enumerweiterungen

### DIFF
--- a/Versionen 1 und 2/HUSST_Ergebnisdaten_2_21.xsd
+++ b/Versionen 1 und 2/HUSST_Ergebnisdaten_2_21.xsd
@@ -881,6 +881,7 @@
 			<enumeration value="Sammelabrechnung"></enumeration>
 			<enumeration value="LogPay"></enumeration>
 			<enumeration value="girocard"></enumeration>
+			<enumeration value="Visa-Electron"></enumeration>
 		</restriction>
 	</simpleType>
 
@@ -1403,6 +1404,8 @@
 			<enumeration value="Zwischenkasse"></enumeration>
 			<enumeration value="Wertbehaelter"></enumeration>
 			<enumeration value="Handkasse"></enumeration>
+			<enumeration value="Recycler"></enumeration>
+			<enumeration value="Unbekannt"></enumeration>
 		</restriction>
 	</simpleType>
 

--- a/Versionen 1 und 2/HUSST_Ergebnisdaten_2_21.xsd
+++ b/Versionen 1 und 2/HUSST_Ergebnisdaten_2_21.xsd
@@ -27,6 +27,8 @@
 			ktTransaktion.BezugsNr erneuert.
 			ktGeraeteTyp entfernt.
 			ktGeraet.Typ wird zu Typ string.
+			ktGeldBehaelterTyp Enum um "Recycler" und "Unbekannt" erweitert.
+			ktZahlArt Enum um "Visa-Electron" erweitert.
 
 		</documentation>
 	</annotation>


### PR DESCRIPTION
ktGeldBehaelterTyp Enum um _Recycler_ und _Unbekannt_ erweitert.
ktZahlArt Enum um _Visa-Electron_ erweitert.