### PR TITLE
Update HUSST_Ergebnisdaten_2_21.xsd

### DIFF
--- a/Versionen 1 und 2/HUSST_Ergebnisdaten_2_21.xsd
+++ b/Versionen 1 und 2/HUSST_Ergebnisdaten_2_21.xsd
@@ -29,6 +29,9 @@
 			ktGeraet.Typ wird zu Typ string.
 			ktGeldBehaelterTyp Enum um "Recycler" und "Unbekannt" erweitert.
 			ktZahlArt Enum um "Visa-Electron" erweitert.
+			
+			ktBetriebsart wurde um den Eintrag "Systembetrieb" erweitert. 
+			Eine Schicht mit der Markeirung Systembetrieb enthält keinen Dienst.
 
 		</documentation>
 	</annotation>
@@ -1514,8 +1517,7 @@
 			<element name="Betriebsart" type="kts:ktBetriebsart"
 				minOccurs="1" maxOccurs="1">
 				<annotation>
-					<documentation>Dieses Feld unterscheidet die Datensätze dieser
-						Schicht in Echt- und sonstigen Betrieb.
+					<documentation>Dieses Feld markiert die konkrete Nutzung Schicht. 
 					</documentation>
 				</annotation>
 			</element>
@@ -1709,6 +1711,7 @@
 			<enumeration value="Echtbetrieb"></enumeration>
 			<enumeration value="Testbetrieb"></enumeration>
 			<enumeration value="Schulungsbetrieb"></enumeration>
+			<enumeration value="Systembetrieb"></enumeration>
 		</restriction>
 	</simpleType>
 


### PR DESCRIPTION
Zu ktBetriebsart den Enumwert "Systembetrieb" hinzugefügt. So kann zwischen weiteren Schichtarten unterschieden werden. 
In Schichten mit der Betriebsart "Systembetrieb" gibt es keinen Dienst und man könnte dann z.B. Hauptsächlich "Meldungen" und "Komponentenliste" zurückgeben.