### PR TITLE
HUSST 3.8.0: Via-Matching über Streckenverlauf

### DIFF
--- a/Version 3/3.8.0/HUSST_Appinfo_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_Appinfo_3_8_0.xsd
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:api="http://husst.de/Appinfo/3_8_0"
+           targetNamespace="http://husst.de/Appinfo/3_8_0"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:documentation>
+      HUSST Appinfo
+      Version: 3.8.0
+
+      Mehr Informationen:
+      - https://husst.de/
+      - https://github.com/HUSST-de/HUSST
+
+      Lizensiert unter CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
+
+      Dieses Dokument dient als ergänzende Definition für Elemente in den XSDs.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:complexType name="field_Type">
+    <xs:annotation>
+      <xs:documentation>Feldname.</xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>Name des Datenfelds.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="primekey_Type">
+    <xs:annotation>
+      <xs:documentation>Primärschlüssel Definition. Liste von einem oder mehreren Datenfelder, die den Primärschlüssel der Datenmenge bilden.
+        Für einen Datentyp darf maximal ein Primärschlüssel definiert sein.
+        Der Primärschlüssel ist immer eindeutig.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="field" type="api:field_Type" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="uniquekey_Type">
+    <xs:annotation>
+      <xs:documentation>Eindeutigkeitsschlüssel Definition.
+        Liste von einem oder mehreren Datenfelder, die einen Eindeutigkeitsschlüssel der Datenmenge bilden.
+        Neben dem häufig technisch definierten Primärschlüssel, kann es ein oder mehrere datenlogische Schlüssel geben,
+        über denen eine Datenmenge eindeutig sein muss.
+        Für einen Datentyp dürfen mehrere Eindeutigkeitsschlüssel definiert sein.
+        Ein Eindeutigkeitsschlüssel darf auch optionale Felder enthalten. Der fehlende Wert ist dann *eine* mögliche
+        Ausprägung des Wertes.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="field" type="api:field_Type" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>Name des Eindeutigkeitsindexes.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="schema_Type">
+    <xs:annotation>
+      <xs:documentation>logisches Daten-Schema, dem die Datenelemente dieses Typs zuzuordnen sind.
+        Außerdem kann für eine Datenlieferung das Vorhandensein dieses Datentyps verlangt werden.
+        Ein Datentyp darf mehreren Schemata zugeordnet sein.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="api:HusstSchema_Type" use="required">
+      <xs:annotation>
+        <xs:documentation>Name des Datenfelds.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="nillable" type="xs:boolean" use="required">
+      <xs:annotation>
+        <xs:documentation>Gibt an, ob für ein Schema Datenelemente von diesem
+          Typ zwingend vorhanden sein müssen.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:simpleType name="HusstSchema_Type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Tarif">
+        <xs:annotation>
+          <xs:documentation>Husst Datenschema Tarif.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="Tarifstrecken">
+        <xs:annotation>
+          <xs:documentation>Husst Datenschema Tarifstrecken.
+            Ergänzung des Datenschemas Tarif um Strukturen für Strecken basierte Tarife wie z.B. den Deutschlandtarif.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="Basis">
+        <xs:annotation>
+          <xs:documentation>Husst Datenschema Basis.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="Angebot">
+        <xs:annotation>
+          <xs:documentation>Husst Datenschema Angebot.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="primekey" type="api:primekey_Type"/>
+  <xs:element name="uniquekey" type="api:uniquekey_Type"/>
+  <xs:element name="schema" type="api:schema_Type"/>
+  <xs:element name="remarks" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>Feld für Hinweise. Z.B. für zukünftige Versionen.</xs:documentation>
+    </xs:annotation>
+  </xs:element>
+</xs:schema>

--- a/Version 3/3.8.0/HUSST_DvBasis_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_DvBasis_3_8_0.xsd
@@ -1,0 +1,2556 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:husstDV="http://husst.de/Versorgungsdaten/3_8_0"
+           xmlns:api="http://www.husst.de/Appinfo/3_8_0"
+           targetNamespace="http://husst.de/Versorgungsdaten/3_8_0"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+  <xs:annotation>
+    <xs:documentation>
+      HUSST Versorgungsdaten - Schema: Basis
+      Version: 3.8.0
+
+      Mehr Informationen:
+      - https://husst.de/
+      - https://github.com/HUSST-de/HUSST
+
+      Lizensiert unter CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
+    </xs:documentation>
+  </xs:annotation>
+  
+  <xs:simpleType name="DateTimeCompact">
+    <xs:restriction base="xs:dateTime">
+      <xs:minInclusive value="1990-01-01T00:00:00Z"/>
+      <xs:maxInclusive value="2117-12-31T23:59:58Z"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="DateCompact">
+    <xs:restriction base="xs:date">
+      <xs:minInclusive value="1990-01-01"/>
+      <xs:maxInclusive value="2117-12-31"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="DauerMinuten">
+    <xs:annotation>
+      <xs:documentation>
+        Definiert eine Dauer. Bei der Interpretation wird auf ganze Minuten geachtet. Sekunden-Angaben werden ignoriert.
+        In der Datenbankabbildung wird ein Integer für eine Anzahl an Minuten empfohlen.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:duration"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="UhrzeitMinuten">
+    <xs:annotation>
+      <xs:documentation>
+        Definiert den Zeitpunkt eines Tages. Bei der Interpretation wird auf ganze Minuten geachtet. Sekunden-Angaben werden ignoriert.
+        In der Datenbankabbildung wird ein Integer für eine Anzahl an Minuten nach 0 Uhr empfohlen.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:time"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="INT1">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="255"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="INT2">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="65535"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="INT4">
+  	<xs:restriction base="xs:unsignedInt">
+  		<xs:minInclusive value="0"/>
+  		<xs:maxInclusive value="4294967295"/>
+  	</xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="INT8">
+    <xs:restriction base="xs:unsignedLong">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="18446744073709551615"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="FLOAT1">
+    <xs:annotation>
+      <xs:documentation>
+        englische Notation beachten, z. B. 19 Euro = 19.00 Euro
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:decimal">
+      <xs:minInclusive value="0"/>
+      <xs:maxInclusive value="100"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="KoordWgs84_Type">
+    <xs:restriction base="xs:float"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="Char">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+      <xs:maxLength value="1"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="String250">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="250"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="blobString">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[ -þ€–]*"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="VersionStatus_Type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="Release"/>
+      <xs:enumeration value="work in progress"/>
+      <xs:enumeration value="stabil"/>
+      <xs:enumeration value="in Arbeit"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="Lang_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Für diese Datenlieferungen sind nur 2-Zeichen Iso-Codes nach ISO
+        639-1:2002 vorgesehen
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:language">
+      <xs:maxLength value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:complexType name="Zeitraeume_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Gültigkeitszeitraum
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ZeitraumVon" type="husstDV:DateTimeCompact" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ZeitraumBis" type="husstDV:DateTimeCompact" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DatenversionZeitraum" type="xs:string" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Eindeutiger Schlüssel für die Datenmenge, die in dem Zeitraum enthalten ist,
+            bezogen auf die DatenversionInhalt des Elements VersionInhalt.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="HauptZeitraumNr" type="husstDV:INT4" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Alle Zeiträume mit dem gleichen
+            Hauptzeitraum
+            bilden einen gemeinsamen Datenraum, in dem
+            alle Refrenzen ID_xx die
+            gleiche Bedeutung haben und
+            auflösbar sind.
+            Sind zu einem Zeitpunkt
+            mehrere Zeiträume mit unterschiedlichen
+            Hauptzeitraumnummern
+            gültig, hat der mit der höheren
+            Hauptzeitraumnummer Vorrang.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="SubZeitraumNr" type="husstDV:INT4" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Die Subzeitraumnummer ist innerhalb einer
+            Hauptzeitraumnummer ununterbrochen, aufsteigend nummeriert,
+            beginnend mit 1.
+            Bei gleichzeitiger Gültigkeit mehrere Subzeiträume
+            hat die höhere
+            SubZeitraumNr Vorrang vor der kleineren.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Zeitraumoptionen_Type">
+    <xs:annotation>
+      <xs:documentation>
+        ordnet einem Zeitraum zusätzliche Optionen zu
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="Option"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Option" type="husstDV:String250" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Schlüsselstring der Option</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Wert" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Kalender_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Kalender mit zugeordneten Tagesarten.
+        Ein Betriebstag ist ein Kalendertag, kann aber abweichende Tagesanfang
+        und -ende haben.
+        Tagesanfang und -ende werden nicht explizit im Kalender definiert.
+
+        Benötigt das System für eine Funktionalität eine ID_Tagesart, dann ermittelt
+        es diese aus dem Kalender.
+        Ist für einen konkreten Kalendertag kein Eintrag im Kalender vorhanden,
+        kann das System über
+        geeignete Tagesartmerkmalelemente eine Default Tagesart aufgrund des
+        Wochentages und allgemein berechenbarer
+        Feiertage ermittelt werden.
+
+        Siehe auch Tagesmerkmale_Type, Tagesmerkmalelemente_Type und
+        Tagsartmerkmalelemente_Type.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Betriebstag"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Betriebstag" type="husstDV:DateCompact" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Datum des Betriebstages</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Betriebstagesart" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Tagesart des Betriebstages
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Tagesarten_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Eine Tagesart beschreibt den logischen Charakter
+        eines Tages soweit der für das vorliegende System benötigt wird.
+        Einem Kalendertag ist genau eine Tagesart zugeordnet.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Betriebstagesart"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Betriebstagesart" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Kennung der Tagesart</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Informationen, welche Bedeutung diese
+            Kennung hat.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Tagesmerkmale_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Ein Tagesmerkmal muss so gestaltet sein, dass an jedem
+        Betriebstag (Kalendertag aber ggf. abweichende Start-/Ende Uhrzeit) aus der
+        Liste der Mermalelemente genau ein Element gültig ist.
+
+        Für eine Tagesart können mehrere Elemente aus einer Liste eines
+        Tagesmerkmales definiert sein.
+
+        Beispiele:
+        Tagesmerkmal:"Wochentag=("Mo","Di","Mi","Do","Fr","Sa","So")
+        Tagesmerkmal:"Ferien"=("Ja","Nein")
+
+        Die Husst Schnittstelle definiert ein Default-Tagesmerkmal mit dem
+        vorgegebenen Bezeichner
+        "husstDefaultermittlung"=("Mo","Di","Mi","Do","Fr","Sa","So","Mo/Feiertag","Di/Feiertag","Mi/Feiertag","Do/Feiertag","Fr/Feiertag","Sa/Feiertag","So/Feiertag")
+        Mit diesem Tagesmerkmal können Tagesarten ausgezeichnet werden, die
+        dann gelten sollen,
+        wenn kein Kalendereintrag gefunden wird. Das Vertriebssystem ermittelt
+        dann aufgrund des Wochentages und der
+        allgemein berechenbaren Feiertage (Einige sind natürlich nicht eindeutig
+        ermittelbar) das husstDefault-Tagesmerkmal
+        und sucht eine Tagesart, für die dieses Merkmal gesetzt ist. Maximal
+        vierzehn Tagesarten können darüber
+        unterschieden werden und keine zwei Tagesarten dürfen eines der Merkmale
+        gemeinsam haben).
+
+        Das Tagesmerkmal "husstDefaultermittlung" muss nicht definiert werden.
+        Wenn eine Datenmenge das Merkmal definiert,
+        darf es nur mit der hier definierten Intension verwendet werden.
+
+        Alle anderen Tagesartmerkmal haben lediglich deklarativen Charakter.
+        Eine vorgegebene Behandlung oder
+        Auswertung ist über den HUSST-Standard nicht definiert.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Tagesmerkmal"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tagesmerkmal" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Kennung des Tagesmerkmals</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Bezeichnungen mit dem Prefix "husst" sind reserviert.
+
+            Die Bezeichnung "husstDefaultermittlung" hat eine definiert Bedeutung
+            (Siehe Tagesmerkmale_Type).
+            Ansonsten kann die Bezeichnung frei vergeben werden.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="TagesmerkmalElemente_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Jedes Tagesmerkmal definiert eine Liste mit
+        unterschiedlichen Tagesmerkmal Elementen.
+        Siehe auch Tagesmerkmale_Type.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_TagesmerkmalElement"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:uniquekey name="Uix_TagesmerkmalElemente">
+          <api:field name="ID_Tagesmerkmal"/>
+          <api:field name="Bezeichnung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:uniquekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_TagesmerkmalElement" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Kennung des Tagesmerkmalelements
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Tagesmerkmal" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Kennung des Tagesmerkmals</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="husstDV:String250" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Eindeutiger Bezeichner des Tagesartmerkmalelements</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="TagesartMerkmalElemente_Type">
+    <xs:annotation>
+      <xs:documentation>
+        TagesartMerkmalElemente vernknüpfen eine Tagesart
+        mit einer Menge von Tagesmerkmal-Elementen.
+
+        Damit beschreibt die Datenmenge lediglich formal die Intension der
+        Tagesart.
+        Lediglich für die Elemente des Tagesmerkmals "husstDefaultermittlung" ist
+        eine funktionale Bedeutung definiert (siehe Tagesmerkmale_Type).
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_TagesartMerkmalElement"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+
+        <api:schema name="Basis"/>
+
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_TagesartMerkmalElement" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Kennung des Tagesartmerkmalelements
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Betriebstagesart" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Kennung der ID_Betriebstagesart
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_TagesmerkmalElement" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Kennung des Tagesmerkmalelements
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <!--Relationen -->
+  
+  <xs:complexType name="Interpretationen_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Interpretationen definiert, wie die Daten zu
+        interpretieren sind.
+        Dazu werden Parameter mit einem
+        Schluessel und einem Wert eingetragen.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="Interpretationsschluessel"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Interpretationsschluessel" type="husstDV:Interpretationsschluessel_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Wert" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <!--Hilfstabellen -->
+  
+  <xs:simpleType name="ID_Projektspezifisch_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Frei definierbare IDs für Def-Elemente beginnen mit 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:minInclusive value="1000"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_WaehrungHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert Waehrungs-ID kleiner 1000
+        Als ID-Währung ist der dreistellige Zifferncode nach ISO 4217 zu verwenden.
+        Außer für den EUR. Hier ist in der HUSST die 999 definiert (ISO Standard wäre 978).
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <!-- ISO 4217 Standard definiert eigentlich 978 für den EUR, 
+           aus historischen Gründen verwendet die HUSST aber die 999 
+      -->
+      <xs:enumeration value="999">
+        <xs:annotation>
+          <xs:documentation>EUR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- auch wenn sie keine aktive Währung mehr ist, 
+           wird die D-Mark aus historischen Gründen noch weiter unterstützt.
+        -->
+      <xs:enumeration value="280">
+        <xs:annotation>
+          <xs:documentation>DEM</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- ab hier (mit Ausnahme des EUR und XXX) 
+           ISO 4217 Standard "list-one.xls" - Stand 1. Januar 2024
+           Quelle: https://www.six-group.com/en/products-services/financial-information/data-standards.html
+      -->
+      <!-- UAE Dirham -->
+      <xs:enumeration value="784">
+        <xs:annotation>
+          <xs:documentation>AED</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Afghani -->
+      <xs:enumeration value="971">
+        <xs:annotation>
+          <xs:documentation>AFN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Lek -->
+      <xs:enumeration value="008">
+        <xs:annotation>
+          <xs:documentation>ALL</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Armenian Dram -->
+      <xs:enumeration value="051">
+        <xs:annotation>
+          <xs:documentation>AMD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Netherlands Antillean Guilder -->
+      <xs:enumeration value="532">
+        <xs:annotation>
+          <xs:documentation>ANG</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Kwanza -->
+      <xs:enumeration value="973">
+        <xs:annotation>
+          <xs:documentation>AOA</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Argentine Peso -->
+      <xs:enumeration value="032">
+        <xs:annotation>
+          <xs:documentation>ARS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Australian Dollar -->
+      <xs:enumeration value="036">
+        <xs:annotation>
+          <xs:documentation>AUD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Aruban Florin -->
+      <xs:enumeration value="533">
+        <xs:annotation>
+          <xs:documentation>AWG</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Azerbaijan Manat -->
+      <xs:enumeration value="944">
+        <xs:annotation>
+          <xs:documentation>AZN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Convertible Mark -->
+      <xs:enumeration value="977">
+        <xs:annotation>
+          <xs:documentation>BAM</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Barbados Dollar -->
+      <xs:enumeration value="052">
+        <xs:annotation>
+          <xs:documentation>BBD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Taka -->
+      <xs:enumeration value="050">
+        <xs:annotation>
+          <xs:documentation>BDT</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Bulgarian Lev -->
+      <xs:enumeration value="975">
+        <xs:annotation>
+          <xs:documentation>BGN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Bahraini Dinar -->
+      <xs:enumeration value="048">
+        <xs:annotation>
+          <xs:documentation>BHD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Burundi Franc -->
+      <xs:enumeration value="108">
+        <xs:annotation>
+          <xs:documentation>BIF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Bermudian Dollar -->
+      <xs:enumeration value="060">
+        <xs:annotation>
+          <xs:documentation>BMD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Brunei Dollar -->
+      <xs:enumeration value="096">
+        <xs:annotation>
+          <xs:documentation>BND</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Boliviano -->
+      <xs:enumeration value="068">
+        <xs:annotation>
+          <xs:documentation>BOB</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Mvdol -->
+      <xs:enumeration value="984">
+        <xs:annotation>
+          <xs:documentation>BOV</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Brazilian Real -->
+      <xs:enumeration value="986">
+        <xs:annotation>
+          <xs:documentation>BRL</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Bahamian Dollar -->
+      <xs:enumeration value="044">
+        <xs:annotation>
+          <xs:documentation>BSD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Ngultrum -->
+      <xs:enumeration value="064">
+        <xs:annotation>
+          <xs:documentation>BTN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Pula -->
+      <xs:enumeration value="072">
+        <xs:annotation>
+          <xs:documentation>BWP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Belarusian Ruble -->
+      <xs:enumeration value="933">
+        <xs:annotation>
+          <xs:documentation>BYN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Belize Dollar -->
+      <xs:enumeration value="084">
+        <xs:annotation>
+          <xs:documentation>BZD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Canadian Dollar -->
+      <xs:enumeration value="124">
+        <xs:annotation>
+          <xs:documentation>CAD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Congolese Franc -->
+      <xs:enumeration value="976">
+        <xs:annotation>
+          <xs:documentation>CDF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- WIR Euro -->
+      <xs:enumeration value="947">
+        <xs:annotation>
+          <xs:documentation>CHE</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Swiss Franc -->
+      <xs:enumeration value="756">
+        <xs:annotation>
+          <xs:documentation>CHF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- WIR Franc -->
+      <xs:enumeration value="948">
+        <xs:annotation>
+          <xs:documentation>CHW</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Unidad de Fomento -->
+      <xs:enumeration value="990">
+        <xs:annotation>
+          <xs:documentation>CLF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Chilean Peso -->
+      <xs:enumeration value="152">
+        <xs:annotation>
+          <xs:documentation>CLP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Yuan Renminbi -->
+      <xs:enumeration value="156">
+        <xs:annotation>
+          <xs:documentation>CNY</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Colombian Peso -->
+      <xs:enumeration value="170">
+        <xs:annotation>
+          <xs:documentation>COP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Unidad de Valor Real -->
+      <xs:enumeration value="970">
+        <xs:annotation>
+          <xs:documentation>COU</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Costa Rican Colon -->
+      <xs:enumeration value="188">
+        <xs:annotation>
+          <xs:documentation>CRC</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Peso Convertible -->
+      <xs:enumeration value="931">
+        <xs:annotation>
+          <xs:documentation>CUC</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Cuban Peso -->
+      <xs:enumeration value="192">
+        <xs:annotation>
+          <xs:documentation>CUP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Cabo Verde Escudo -->
+      <xs:enumeration value="132">
+        <xs:annotation>
+          <xs:documentation>CVE</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Czech Koruna -->
+      <xs:enumeration value="203">
+        <xs:annotation>
+          <xs:documentation>CZK</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Djibouti Franc -->
+      <xs:enumeration value="262">
+        <xs:annotation>
+          <xs:documentation>DJF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Danish Krone -->
+      <xs:enumeration value="208">
+        <xs:annotation>
+          <xs:documentation>DKK</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Dominican Peso -->
+      <xs:enumeration value="214">
+        <xs:annotation>
+          <xs:documentation>DOP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Algerian Dinar -->
+      <xs:enumeration value="012">
+        <xs:annotation>
+          <xs:documentation>DZD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Egyptian Pound -->
+      <xs:enumeration value="818">
+        <xs:annotation>
+          <xs:documentation>EGP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Nakfa -->
+      <xs:enumeration value="232">
+        <xs:annotation>
+          <xs:documentation>ERN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Ethiopian Birr -->
+      <xs:enumeration value="230">
+        <xs:annotation>
+          <xs:documentation>ETB</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Fiji Dollar -->
+      <xs:enumeration value="242">
+        <xs:annotation>
+          <xs:documentation>FJD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Falkland Islands Pound -->
+      <xs:enumeration value="238">
+        <xs:annotation>
+          <xs:documentation>FKP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Pound Sterling -->
+      <xs:enumeration value="826">
+        <xs:annotation>
+          <xs:documentation>GBP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Lari -->
+      <xs:enumeration value="981">
+        <xs:annotation>
+          <xs:documentation>GEL</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Ghana Cedi -->
+      <xs:enumeration value="936">
+        <xs:annotation>
+          <xs:documentation>GHS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Gibraltar Pound -->
+      <xs:enumeration value="292">
+        <xs:annotation>
+          <xs:documentation>GIP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Dalasi -->
+      <xs:enumeration value="270">
+        <xs:annotation>
+          <xs:documentation>GMD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Guinean Franc -->
+      <xs:enumeration value="324">
+        <xs:annotation>
+          <xs:documentation>GNF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Quetzal -->
+      <xs:enumeration value="320">
+        <xs:annotation>
+          <xs:documentation>GTQ</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Guyana Dollar -->
+      <xs:enumeration value="328">
+        <xs:annotation>
+          <xs:documentation>GYD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Hong Kong Dollar -->
+      <xs:enumeration value="344">
+        <xs:annotation>
+          <xs:documentation>HKD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Lempira -->
+      <xs:enumeration value="340">
+        <xs:annotation>
+          <xs:documentation>HNL</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Gourde -->
+      <xs:enumeration value="332">
+        <xs:annotation>
+          <xs:documentation>HTG</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Forint -->
+      <xs:enumeration value="348">
+        <xs:annotation>
+          <xs:documentation>HUF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Rupiah -->
+      <xs:enumeration value="360">
+        <xs:annotation>
+          <xs:documentation>IDR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- New Israeli Sheqel -->
+      <xs:enumeration value="376">
+        <xs:annotation>
+          <xs:documentation>ILS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Indian Rupee -->
+      <xs:enumeration value="356">
+        <xs:annotation>
+          <xs:documentation>INR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Iraqi Dinar -->
+      <xs:enumeration value="368">
+        <xs:annotation>
+          <xs:documentation>IQD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Iranian Rial -->
+      <xs:enumeration value="364">
+        <xs:annotation>
+          <xs:documentation>IRR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Iceland Krona -->
+      <xs:enumeration value="352">
+        <xs:annotation>
+          <xs:documentation>ISK</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Jamaican Dollar -->
+      <xs:enumeration value="388">
+        <xs:annotation>
+          <xs:documentation>JMD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Jordanian Dinar -->
+      <xs:enumeration value="400">
+        <xs:annotation>
+          <xs:documentation>JOD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Yen -->
+      <xs:enumeration value="392">
+        <xs:annotation>
+          <xs:documentation>JPY</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Kenyan Shilling -->
+      <xs:enumeration value="404">
+        <xs:annotation>
+          <xs:documentation>KES</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Som -->
+      <xs:enumeration value="417">
+        <xs:annotation>
+          <xs:documentation>KGS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Riel -->
+      <xs:enumeration value="116">
+        <xs:annotation>
+          <xs:documentation>KHR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Comorian Franc  -->
+      <xs:enumeration value="174">
+        <xs:annotation>
+          <xs:documentation>KMF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- North Korean Won -->
+      <xs:enumeration value="408">
+        <xs:annotation>
+          <xs:documentation>KPW</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Won -->
+      <xs:enumeration value="410">
+        <xs:annotation>
+          <xs:documentation>KRW</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Kuwaiti Dinar -->
+      <xs:enumeration value="414">
+        <xs:annotation>
+          <xs:documentation>KWD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Cayman Islands Dollar -->
+      <xs:enumeration value="136">
+        <xs:annotation>
+          <xs:documentation>KYD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Tenge -->
+      <xs:enumeration value="398">
+        <xs:annotation>
+          <xs:documentation>KZT</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Lao Kip -->
+      <xs:enumeration value="418">
+        <xs:annotation>
+          <xs:documentation>LAK</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Lebanese Pound -->
+      <xs:enumeration value="422">
+        <xs:annotation>
+          <xs:documentation>LBP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Sri Lanka Rupee -->
+      <xs:enumeration value="144">
+        <xs:annotation>
+          <xs:documentation>LKR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Liberian Dollar -->
+      <xs:enumeration value="430">
+        <xs:annotation>
+          <xs:documentation>LRD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Loti -->
+      <xs:enumeration value="426">
+        <xs:annotation>
+          <xs:documentation>LSL</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Libyan Dinar -->
+      <xs:enumeration value="434">
+        <xs:annotation>
+          <xs:documentation>LYD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Moroccan Dirham -->
+      <xs:enumeration value="504">
+        <xs:annotation>
+          <xs:documentation>MAD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Moldovan Leu -->
+      <xs:enumeration value="498">
+        <xs:annotation>
+          <xs:documentation>MDL</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Malagasy Ariary -->
+      <xs:enumeration value="969">
+        <xs:annotation>
+          <xs:documentation>MGA</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Denar -->
+      <xs:enumeration value="807">
+        <xs:annotation>
+          <xs:documentation>MKD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Kyat -->
+      <xs:enumeration value="104">
+        <xs:annotation>
+          <xs:documentation>MMK</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Tugrik -->
+      <xs:enumeration value="496">
+        <xs:annotation>
+          <xs:documentation>MNT</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Pataca -->
+      <xs:enumeration value="446">
+        <xs:annotation>
+          <xs:documentation>MOP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Ouguiya -->
+      <xs:enumeration value="929">
+        <xs:annotation>
+          <xs:documentation>MRU</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Mauritius Rupee -->
+      <xs:enumeration value="480">
+        <xs:annotation>
+          <xs:documentation>MUR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Rufiyaa -->
+      <xs:enumeration value="462">
+        <xs:annotation>
+          <xs:documentation>MVR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Malawi Kwacha -->
+      <xs:enumeration value="454">
+        <xs:annotation>
+          <xs:documentation>MWK</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Mexican Peso -->
+      <xs:enumeration value="484">
+        <xs:annotation>
+          <xs:documentation>MXN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Mexican Unidad de Inversion (UDI) -->
+      <xs:enumeration value="979">
+        <xs:annotation>
+          <xs:documentation>MXV</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Malaysian Ringgit -->
+      <xs:enumeration value="458">
+        <xs:annotation>
+          <xs:documentation>MYR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Mozambique Metical -->
+      <xs:enumeration value="943">
+        <xs:annotation>
+          <xs:documentation>MZN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Namibia Dollar -->
+      <xs:enumeration value="516">
+        <xs:annotation>
+          <xs:documentation>NAD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Naira -->
+      <xs:enumeration value="566">
+        <xs:annotation>
+          <xs:documentation>NGN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Cordoba Oro -->
+      <xs:enumeration value="558">
+        <xs:annotation>
+          <xs:documentation>NIO</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Norwegian Krone -->
+      <xs:enumeration value="578">
+        <xs:annotation>
+          <xs:documentation>NOK</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Nepalese Rupee -->
+      <xs:enumeration value="524">
+        <xs:annotation>
+          <xs:documentation>NPR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- New Zealand Dollar -->
+      <xs:enumeration value="554">
+        <xs:annotation>
+          <xs:documentation>NZD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Rial Omani -->
+      <xs:enumeration value="512">
+        <xs:annotation>
+          <xs:documentation>OMR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Balboa -->
+      <xs:enumeration value="590">
+        <xs:annotation>
+          <xs:documentation>PAB</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Sol -->
+      <xs:enumeration value="604">
+        <xs:annotation>
+          <xs:documentation>PEN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Kina -->
+      <xs:enumeration value="598">
+        <xs:annotation>
+          <xs:documentation>PGK</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Philippine Peso -->
+      <xs:enumeration value="608">
+        <xs:annotation>
+          <xs:documentation>PHP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Pakistan Rupee -->
+      <xs:enumeration value="586">
+        <xs:annotation>
+          <xs:documentation>PKR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Zloty -->
+      <xs:enumeration value="985">
+        <xs:annotation>
+          <xs:documentation>PLN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Guarani -->
+      <xs:enumeration value="600">
+        <xs:annotation>
+          <xs:documentation>PYG</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Qatari Rial -->
+      <xs:enumeration value="634">
+        <xs:annotation>
+          <xs:documentation>QAR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Romanian Leu -->
+      <xs:enumeration value="946">
+        <xs:annotation>
+          <xs:documentation>RON</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Serbian Dinar -->
+      <xs:enumeration value="941">
+        <xs:annotation>
+          <xs:documentation>RSD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Russian Ruble -->
+      <xs:enumeration value="643">
+        <xs:annotation>
+          <xs:documentation>RUB</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Rwanda Franc -->
+      <xs:enumeration value="646">
+        <xs:annotation>
+          <xs:documentation>RWF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Saudi Riyal -->
+      <xs:enumeration value="682">
+        <xs:annotation>
+          <xs:documentation>SAR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Solomon Islands Dollar -->
+      <xs:enumeration value="090">
+        <xs:annotation>
+          <xs:documentation>SBD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Seychelles Rupee -->
+      <xs:enumeration value="690">
+        <xs:annotation>
+          <xs:documentation>SCR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Sudanese Pound -->
+      <xs:enumeration value="938">
+        <xs:annotation>
+          <xs:documentation>SDG</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Swedish Krona -->
+      <xs:enumeration value="752">
+        <xs:annotation>
+          <xs:documentation>SEK</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Singapore Dollar -->
+      <xs:enumeration value="702">
+        <xs:annotation>
+          <xs:documentation>SGD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Saint Helena Pound -->
+      <xs:enumeration value="654">
+        <xs:annotation>
+          <xs:documentation>SHP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Leone -->
+      <xs:enumeration value="925">
+        <xs:annotation>
+          <xs:documentation>SLE</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Somali Shilling -->
+      <xs:enumeration value="706">
+        <xs:annotation>
+          <xs:documentation>SOS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Surinam Dollar -->
+      <xs:enumeration value="968">
+        <xs:annotation>
+          <xs:documentation>SRD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- South Sudanese Pound -->
+      <xs:enumeration value="728">
+        <xs:annotation>
+          <xs:documentation>SSP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Dobra -->
+      <xs:enumeration value="930">
+        <xs:annotation>
+          <xs:documentation>STN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- El Salvador Colon -->
+      <xs:enumeration value="222">
+        <xs:annotation>
+          <xs:documentation>SVC</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Syrian Pound -->
+      <xs:enumeration value="760">
+        <xs:annotation>
+          <xs:documentation>SYP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Lilangeni -->
+      <xs:enumeration value="748">
+        <xs:annotation>
+          <xs:documentation>SZL</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Baht -->
+      <xs:enumeration value="764">
+        <xs:annotation>
+          <xs:documentation>THB</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Somoni -->
+      <xs:enumeration value="972">
+        <xs:annotation>
+          <xs:documentation>TJS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Turkmenistan New Manat -->
+      <xs:enumeration value="934">
+        <xs:annotation>
+          <xs:documentation>TMT</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Tunisian Dinar -->
+      <xs:enumeration value="788">
+        <xs:annotation>
+          <xs:documentation>TND</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Pa’anga -->
+      <xs:enumeration value="776">
+        <xs:annotation>
+          <xs:documentation>TOP</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Turkish Lira -->
+      <xs:enumeration value="949">
+        <xs:annotation>
+          <xs:documentation>TRY</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Trinidad and Tobago Dollar -->
+      <xs:enumeration value="780">
+        <xs:annotation>
+          <xs:documentation>TTD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- New Taiwan Dollar -->
+      <xs:enumeration value="901">
+        <xs:annotation>
+          <xs:documentation>TWD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Tanzanian Shilling -->
+      <xs:enumeration value="834">
+        <xs:annotation>
+          <xs:documentation>TZS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Hryvnia -->
+      <xs:enumeration value="980">
+        <xs:annotation>
+          <xs:documentation>UAH</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Uganda Shilling -->
+      <xs:enumeration value="800">
+        <xs:annotation>
+          <xs:documentation>UGX</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- US Dollar -->
+      <xs:enumeration value="840">
+        <xs:annotation>
+          <xs:documentation>USD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- US Dollar (Next day) -->
+      <xs:enumeration value="997">
+        <xs:annotation>
+          <xs:documentation>USN</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Uruguay Peso en Unidades Indexadas (UI) -->
+      <xs:enumeration value="940">
+        <xs:annotation>
+          <xs:documentation>UYI</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Peso Uruguayo -->
+      <xs:enumeration value="858">
+        <xs:annotation>
+          <xs:documentation>UYU</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Unidad Previsional -->
+      <xs:enumeration value="927">
+        <xs:annotation>
+          <xs:documentation>UYW</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Uzbekistan Sum -->
+      <xs:enumeration value="860">
+        <xs:annotation>
+          <xs:documentation>UZS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Bolívar Soberano -->
+      <xs:enumeration value="926">
+        <xs:annotation>
+          <xs:documentation>VED</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Bolívar Soberano -->
+      <xs:enumeration value="928">
+        <xs:annotation>
+          <xs:documentation>VES</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Dong -->
+      <xs:enumeration value="704">
+        <xs:annotation>
+          <xs:documentation>VND</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Vatu -->
+      <xs:enumeration value="548">
+        <xs:annotation>
+          <xs:documentation>VUV</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Tala -->
+      <xs:enumeration value="882">
+        <xs:annotation>
+          <xs:documentation>WST</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- CFA Franc BEAC -->
+      <xs:enumeration value="950">
+        <xs:annotation>
+          <xs:documentation>XAF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Silver -->
+      <xs:enumeration value="961">
+        <xs:annotation>
+          <xs:documentation>XAG</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Gold -->
+      <xs:enumeration value="959">
+        <xs:annotation>
+          <xs:documentation>XAU</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Bond Markets Unit European Composite Unit (EURCO) -->
+      <xs:enumeration value="955">
+        <xs:annotation>
+          <xs:documentation>XBA</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Bond Markets Unit European Monetary Unit (E.M.U.-6) -->
+      <xs:enumeration value="956">
+        <xs:annotation>
+          <xs:documentation>XBB</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Bond Markets Unit European Unit of Account 9 (E.U.A.-9) -->
+      <xs:enumeration value="957">
+        <xs:annotation>
+          <xs:documentation>XBC</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Bond Markets Unit European Unit of Account 17 (E.U.A.-17) -->
+      <xs:enumeration value="958">
+        <xs:annotation>
+          <xs:documentation>XBD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- East Caribbean Dollar -->
+      <xs:enumeration value="951">
+        <xs:annotation>
+          <xs:documentation>XCD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- SDR (Special Drawing Right) -->
+      <xs:enumeration value="960">
+        <xs:annotation>
+          <xs:documentation>XDR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- CFA Franc BCEAO -->
+      <xs:enumeration value="952">
+        <xs:annotation>
+          <xs:documentation>XOF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Palladium -->
+      <xs:enumeration value="964">
+        <xs:annotation>
+          <xs:documentation>XPD</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- CFP Franc -->
+      <xs:enumeration value="953">
+        <xs:annotation>
+          <xs:documentation>XPF</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Platinum -->
+      <xs:enumeration value="962">
+        <xs:annotation>
+          <xs:documentation>XPT</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Sucre -->
+      <xs:enumeration value="994">
+        <xs:annotation>
+          <xs:documentation>XSU</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Codes specifically reserved for testing purposes -->
+      <xs:enumeration value="963">
+        <xs:annotation>
+          <xs:documentation>XTS</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- ADB Unit of Account -->
+      <xs:enumeration value="965">
+        <xs:annotation>
+          <xs:documentation>XUA</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Yemeni Rial -->
+      <xs:enumeration value="886">
+        <xs:annotation>
+          <xs:documentation>YER</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Rand -->
+      <xs:enumeration value="710">
+        <xs:annotation>
+          <xs:documentation>ZAR</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Zambian Kwacha -->
+      <xs:enumeration value="967">
+        <xs:annotation>
+          <xs:documentation>ZMW</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!-- Zimbabwe Dollar -->
+      <xs:enumeration value="932">
+        <xs:annotation>
+          <xs:documentation>ZWL</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Waehrung_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Waehrung ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_WaehrungHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="InterpretationsschluesselHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert Interpretationsschluessel die mit 'husst.' beginnen.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="husst.Relationen.Matrixtyp">
+        <xs:annotation>
+          <xs:documentation>
+            Definiert, wie die Relationenmatrix zu interpretieren ist.
+            mögliche Matrixtypen sind
+            "Vollmatrix" : Jede Verbindung ist in jeder erlaubten Richtung in der Relationenmatrix hinterlegt.
+            "Halbmatrix" : Zu jeder möglichen Verbindung ist nur die Variante ID_RelcodeStart größer gleich ID_RelcodeZiel hinterlegt, die umgekehrte Richtung ist dazu identisch.
+            "erweitert Halbmatrix" : Die Relationen werden im Regelfall mit ID_RelcodeStart größer gleich ID_RelcodeZiel definiert, es kann aber auch die Rückrichtung definiert
+            sein,
+            dann muss das Flag GegenrichtungLiegtVor auf true gesetzt werden.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="husst.Relationen.Suchstrategie">
+        <xs:annotation>
+          <xs:documentation>
+            Definiert, wie die Ermittlung einer Verkaufsverbindung erfolgen soll.
+            Ist der Schlüssel nicht definiert, wird über ID_RelcodeStart und ID_RelcodeZiel in den Relationen nach einer oder mehreren Verbindungen gesucht.
+            mögliche Suchstrategien sind
+            "NbHstSuche + RCSuche" : Suchstrategie für die Relationsermittlung: Nachbarhaltestellensuche zusätzlich zur Relationscodesuche.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="husst.Teilrelationen.Matrixpreisbildung">
+        <xs:annotation>
+          <xs:documentation>
+            Definiert, wie die Preisbildung aus den Teilrelationen erfolgen soll.
+            Ist der Schlüssel nicht definiert, wird der Preis anhand der ID_Preisstufe der ersten Teilrelation ermittelt.
+            mögliche Matrixpreisbildungen sind
+            "Anstoß_CH" : Wenn nur eine Teilrelation exisitiert, dann wie beim Standardfall.
+            Sonst: Preisstufenattribute werden von der Preisstufe der ersten Teilrelation verwendet.
+            Der Preis wird nach einer eigenen CH-Logik aus den weiteren Teilrelationen berechnet.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="InterpretationsschluesselProjektspezifisch_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Für projektspezifische Zwecke oder zum Test
+        können eigene Namen für Interpretationsschluessel verwendet werden.
+
+        Namensregeln:
+        Eigene Namen ..
+        .. dürfen nicht mit 'husst.' beginnen,
+        .. dürfen nicht mit einer Zahl beginnen,
+        .. müssen mindestens ein Zeichen [a-ZöäüÖÄÜß\-0-9] je Wort enthalten
+        .. müssen mit einem Wort beginnen,
+        .. dürfen mehrere Wörter mit '.' oder '-' trennen,
+        .. dürfen nicht mit einem Punkt enden.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="((h[^u])|hu[^s]|hus[^s]|huss[^t]|husst[^\.]|[a-gi-zA-ZöäüÖÄÜß][a-zA-ZöäüÖÄÜß0-9]*)([\-\.][a-zA-ZöäüÖÄÜß0-9]+)*"/>
+      <!-- 				value="(((h|H)[^(u|U)])|(h|H)(u|U)[^(s|S)]|(h|H)(u|U)(s|S)[^(s|S)]|(h|H)(u|U)(s|S)(s|S)[^(t|T)]|(h|H)(u|U)(s|S)(s|S)(t|T)[^\.]|[a-gi-zA-ZöäüÖÄÜß0-9])((\w*[a-zA-ZöäüÖÄÜß]\w*)+([\-\.]))*(\w*[a-zA-ZöäüÖÄÜß]\w*)+" /> -->
+      <!-- Leider untersützt xsd keinen negativen Forcast (?!husst\.), das
+				macht den Ausdruck unnötig kompliziert. <pattern value="(?!husst\.)((\w*[a-zA-ZöäüÖÄÜß]\w*)+([\-\.]))*(\w*[a-zA-ZöäüÖÄÜß]\w*)+"/> -->
+
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="Interpretationsschluessel_Type">
+    <xs:annotation>
+      <xs:documentation>Die Interpretationsschluessel sind entweder von der HUSST vordefiniert oder eine im Projekt vereinbarter string.</xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:InterpretationsschluesselHUSST_Type husstDV:InterpretationsschluesselProjektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefWaehrung_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Waehrung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+      <xs:documentation>Definiert die Währungen, die in den Versorgungsdaten vorkommen (können). Siehe auch ID_Waehrung_Type bzw. ID_WaehrungHUSST_Type</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Waehrung" type="husstDV:ID_Waehrung_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            ISO-Kurzbezeichnung z.B. EUR, USD, CHF,...
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Updateinfo_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Dokumentation von Updatevorgängen über der zunächst
+        generierten Datenmenge
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="Updatetime"/>
+          <api:field name="Filename"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Updatetime" type="husstDV:DateTimeCompact" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Zeitpunkt des Updatevorgangs
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Filename" type="xs:string" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Filename des Updatescripts oder Bezeichnung des Updatevorgangs
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Purpose" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Hinweis zum Zweck des Updatevorgangs
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="VersionInhalt_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="DatenversionInhalt"/>
+          <api:field name="Erstellungsdatum"/>
+          <api:field name="Lieferant"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+
+      </xs:appinfo>
+      <xs:documentation>Eine Datenlieferung enthält einen Datensatz VersionInhalt.
+        Dieser definiert, welche Datenversion die komplette Husstlieferung besitzt.
+        Dieses ist eine Metainformation um diese Lieferung einfach von anderen zu unterscheiden.
+        Über die Registrierung Der DatenversionInhalt können Verkaufsdaten ihrer exakten Versorgungsdatenlieferung zugewordnet werden.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+
+      <xs:element name="DatenversionInhalt" type="xs:string" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Eindeutige Versionskennung für die gesamte Datenlieferung.
+            In der gesamten Datenlieferung darf dieses Element nur einmal vorkommen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Testdaten" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Erstellungsdatum" type="husstDV:DateTimeCompact" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Lieferant" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Kommentar" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Bearbeitung_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="Bearbeitungsdatum"/>
+          <api:field name="Lieferant"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Bearbeitungsdatum" type="husstDV:DateTimeCompact" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Lieferant" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Kommentar" type="xs:string" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="VersionStruktur_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="VersionMajor" type="husstDV:INT4" maxOccurs="1" minOccurs="1" default="3">
+        <xs:annotation>
+          <xs:documentation>VersionMajor muss sich immer bei Inkompatibilitäten zur Vorgängerversion ändern.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="VersionMinor" type="husstDV:INT4" maxOccurs="1" minOccurs="1" default="7">
+        <xs:annotation>
+          <xs:documentation>VersionMinor zählt kompatible Anpassungen.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="VersionPatch" type="husstDV:INT4" maxOccurs="1" minOccurs="1" default="0">
+        <xs:annotation>
+          <xs:documentation>VersionPatch zählt abwärtskompatible Bugfixes.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Status" type="husstDV:VersionStatus_Type" default="Release" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Aenderungsdatum" type="husstDV:DateCompact" default="2025-01-15" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="Aenderungsautor" type="xs:string" default="HUSST-Arbeitsgruppe" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefBundesland_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Definiert einen Gliedstaat (in Deutschland: Bundesland).
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Bundesland"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Bundesland" type="husstDV:ID_Bundesland_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Iso" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Für Deutschland: die letzten zwei Stellen des ISO
+            3166-2 Codes für Gliedstaaten.
+            DE-BW Baden-Württemberg also: BW
+            DE-BY Bayern also: BY
+            DE-BE Berlin also: BE
+            DE-BB Brandenburg also: BB
+            DE-HB Bremen also: HB
+            DE-HH Hamburg also: HH
+            DE-HE Hessen also: HE
+            DE-MV Mecklenburg-Vorpommern also: MV
+            DE-NI Niedersachsen also: NI
+            DE-NW Nordrhein-Westfalen also: NW
+            DE-RP Rheinland-Pfalz also: RP
+            DE-SL Saarland also: SL
+            DE-SN Sachsen also: SN
+            DE-ST Sachsen-Anhalt also: ST
+            DE-SH Schleswig-Holstein also: SH
+            DE-TH Thüringen also: TH
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Name des Bundeslandes</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_BundeslandHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Bundesland kleiner 1000.
+        Aktuell definiert die HUSST ID_Bundesland für die deutschen Bundesländern
+        analog der "Liste deutscher Bundesländer" wie sie für den Amtlicher Regionalschlüssel (ARS) 
+        bzw. dem darin enthaltenen Amtlichen Gemeindeschlüssel (AGS) definiert sind. 
+        
+        Quelle: 02Bundeslaender_mit_Hauptstaedten.xslx - Statistisches Bundesamt (Destatis), 2023
+        https://www.destatis.de/DE/Themen/Laender-Regionen/Regionales/Gemeindeverzeichnis/Administrativ/Archiv/Standardtabellen/02_BundeslaenderVorjahr.html
+        
+        Dieser 2-stellige Länderschlüssel wird u.a. auch in der DHID/Global-ID (=Landeskennzeichen(LK)) 
+        verwendet und damit im deutschlandweiten zentralen Haltestellenverzeichnis (zHV)
+         - siehe auch VDV-Schrift 432: https://www.vdv.de/downloads/3855/432SDS/forced.
+      </xs:documentation>
+    </xs:annotation>
+  
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>unbekannt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Schleswig-Holstein (SH)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Hamburg (HH)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Niedersachsen (NI)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>Bremen (HB)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="5">
+        <xs:annotation>
+          <xs:documentation>Nordrhein-Westfalen (NW)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="6">
+        <xs:annotation>
+          <xs:documentation>Hessen (HE)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="7">
+        <xs:annotation>
+          <xs:documentation>Rheinland-Pfalz (RP)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="8">
+        <xs:annotation>
+          <xs:documentation>Baden-Württemberg (BW)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="9">
+        <xs:annotation>
+          <xs:documentation>Bayern (BY)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="10">
+        <xs:annotation>
+          <xs:documentation>Saarland (SL)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="11">
+        <xs:annotation>
+          <xs:documentation>Berlin (BE)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="12">
+        <xs:annotation>
+          <xs:documentation>Brandenburg (BB)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="13">
+        <xs:annotation>
+          <xs:documentation>Mecklenburg-Vorpommern (MV)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="14">
+        <xs:annotation>
+          <xs:documentation>Sachsen (SN)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="15">
+        <xs:annotation>
+          <xs:documentation>Sachsen-Anhalt (ST)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    
+      <xs:enumeration value="16">
+        <xs:annotation>
+          <xs:documentation>Thüringen (TH)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Bundesland_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Bundesland ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_BundeslandHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="Feiertage_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Feiertag"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:uniquekey name="Uix_Feiertage">
+          <api:field name="Datum"/>
+          <api:field name="ID_Bundesland"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:uniquekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Feiertag" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Bundesland" type="husstDV:ID_Bundesland_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Datum" type="husstDV:DateCompact" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Unternehmen_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Unternehmen"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+      <xs:documentation>Unternehmen definieren organisatorische Einheiten, die in dem Vertriebssystem eine Rolle übernehmen.
+        Wenn sie die Rolle eines Mandanten im System übernehmen, kann dies über ihre Mandant Eigenschaft angezeigt werden.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Unternehmen" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="BezeichnungKurz" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Mandant" type="xs:boolean" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            True, wenn das Unternehmen als Mandant im System geführt
+            wird.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" maxOccurs="1" minOccurs="0" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um Unternehmen über eine nicht numerische
+            Referenz ggf. auch bezogen auf Drittsysteme identifizieren
+            zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:element name="VersionInhalt" type="husstDV:VersionInhalt_Type"/>
+  
+  <xs:element name="Bearbeitung" type="husstDV:Bearbeitung_Type"/>
+  
+  <xs:element name="DefBundeslaender" type="husstDV:DefBundesland_Type"/>
+  
+  <xs:element name="Zeitraeume" type="husstDV:Zeitraeume_Type"/>
+  
+  <xs:element name="Zeitraumoptionen" type="husstDV:Zeitraumoptionen_Type"/>
+  
+  <xs:element name="Kalender" type="husstDV:Kalender_Type"/>
+  
+  <xs:element name="Tagesarten" type="husstDV:Tagesarten_Type"/>
+  
+  <xs:element name="Tagesmerkmale" type="husstDV:Tagesmerkmale_Type"/>
+  
+  <xs:element name="TagesmerkmalElemente" type="husstDV:TagesmerkmalElemente_Type"/>
+  
+  <xs:element name="TagesartMerkmalElemente" type="husstDV:TagesartMerkmalElemente_Type"/>
+  
+  <xs:element name="Feiertage" type="husstDV:Feiertage_Type"/>
+  
+  <xs:element name="Unternehmen" type="husstDV:Unternehmen_Type"/>
+  
+  <xs:element name="Interpretationen" type="husstDV:Interpretationen_Type"/>
+  
+  <xs:element name="DefWaehrungen" type="husstDV:DefWaehrung_Type"/>
+  
+  <xs:element name="VersionStruktur" type="husstDV:VersionStruktur_Type"/>
+  
+  <xs:element name="Updateinfo" type="husstDV:Updateinfo_Type"/>
+  
+  <xs:complexType name="DynAttributDef_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Definition der dynamischen Attribute, die in dieser
+        Datenmenge verwendet werden.
+
+        Dynamische Attribute ergänzen einen
+        Datentyp um weitere
+        Eigenschaften. Jedem Datensatz kann für seinen
+        eindeutigen Datensatzschlüssel (ID_[Typname]
+        , z.B. ID_Sorte), der
+        Tabellennummer und der ID
+        einer dynamischen Attribut-Definition ein
+        konkreter
+        Wert für diese Eigenschaft hinterlegt werden.
+
+        Da die AttributDef-Struktur ausschließlich der Interpretation der
+        Daten innerhalb der abgeschlossenen Datenlieferung dient, benötigt
+        sie weder eine deaktiviert Kennung noch eine Referenz auf einen
+        spezifischen Zeitraum innerhalb der Datenmenge.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_DynAttributDef"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ID_DynAttributDef" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Referenznummer der dynamischen Attributdefinition.
+            Die Nummer hat nur innerhalb der Datenmenge eine Bedeutung und kann
+            nicht als persistent vorausgesetzt werden.
+          </xs:documentation>
+          <xs:appinfo>
+
+          </xs:appinfo>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Name" type="xs:string" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Interner Name des dynamischen Attributs. Die
+            möglichen Namen dynamischer Attribute werden bei krauth technology
+            zentral verwaltet. Dabei werden, wenn vorhanden, die in der offen
+            Husst-Schnittstelle abgestimmten Definitionen einbezogen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttributTyp" type="husstDV:DynAttributTyp_Type" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Der Datentyp der konkreten Daten die unter der
+            ID_DynAttributDef in der Datenmenge DynAttribut_Type im Feld Wert
+            als String-Information abgelegt ist.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="DynAttributTyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die Werte eines dynamischen Attributes werden als
+        String
+        abgelegt. Wie dieser zu verstehen ist, wird durch den
+        DynAttributTyp definiert.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="int">
+        <xs:annotation>
+          <xs:documentation>vorzeichenbehaftete Ganzzahl</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="bool">
+        <xs:annotation>
+          <xs:documentation>
+            logischer Wert, Wertebereich "0" für false oder
+            "1" für true
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="string">
+        <xs:annotation>
+          <xs:documentation>Zeichenkette</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="datetime">
+        <xs:annotation>
+          <xs:documentation>
+            Zeitpunkt (Datum/Uhrzeit) nach ISO8601 -
+            (Beispiel: 2014-06-10T07:46+02:00, eine Angabe ohne die Abweichung
+            von der UTC-Zeit ist auch zulässig)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="hex">
+        <xs:annotation>
+          <xs:documentation>
+            hexadezimal codierter Datenstring - zulässige
+            Zeichen: '0'-'9', 'a'-'f', 'A'-'F'. Niederwertiges Byte zuerst,
+            höherwertiges Halb-Byte zuerst.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="id_sprachtext">
+        <xs:annotation>
+          <xs:documentation>
+            vorzeichenlose Ganzzahl, Verweis auf
+            ID_Sprachtext in der Tabelle Sprachtexte, einen möglicherweise
+            mehrsprachig hinterlegten Text
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:complexType name="DynAttributWert_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die Tabelle enthält den Wert eines dynamischen Attributs.
+
+        Die Werte der dynamischen Attribute sind an die ID eines Datensatzes
+        und damit auch an die ID eines konkreten Zeitraumes gekoppelt.
+        Deshalb wird die Eigenschaft ID_Zeitraum benötigt. Bezieht sich ein
+        dynamisches Attribut auf eine Tabellennummer, deren Struktur selbst
+        keine ID_Zeitraum Eigenschaft besitzt (z.B. Inhalt_Type), dann
+        bleibt ID_Zeitraum leer.
+
+        Anders verhält es sich mit der Deaktiviert Eigenschaft. Diese bezieht sich
+        explizit auf den gesamten Datensatz einer Datenstruktur. Formal wäre
+        dies für die DynAttributWert Tabelle verwendbar. Allerdings bildet
+        ein Eintrag in der DynAttributWert Tabelle nur ein Attribut
+        innerhalb eines Datensatzes einer anderen Struktur ab. Diese andere
+        Struktur besitzt den Deaktiviert Mechanismus für ihren Datensatz und
+        damit auch für alle dynamischen Attribute, die an diesem Datensatz
+        hängen.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_DynAttributDef"/>
+          <api:field name="ID_DatensatzRef"/>
+          <api:field name="Tabellennummer"/>
+          <api:field name="ID_Zeitraum"/>
+          <api:field name="Lang"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_DynAttributDef" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Referenznummer der dynamischen Attributdefinition.
+            Die Nummer hat nur innerhalb der Datenmenge eine Bedeutung und kann
+            nicht als persistent vorausgesetzt werden.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Tabellennummer" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Eindeutige Nummer der referenzierten
+            Datenstruktur. Neben dem eindeutigen Namen jedes
+            Datentyps (z.B. Tarifgebiet für
+            Tarifgebiet_Type) der aus dem Typnamen
+            regelbasiert abgeleitet wird, erhält jeder Typ
+            eine eindeutige Tabellennummer. Damit muss nicht
+            bei jeder Datenmenge eine numerische ID für
+            jeden Datentyp abgelegt werden. Andererseits
+            kann bei Referenzen wie DynAttributWert die
+            Tabellennummer viel effizienter als
+            Schlüsselwert verwendet werden, als ein
+            entsprechender Name.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_DatensatzRef" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Eindeutiger Datensatzschlüssel (ID_[Typname])
+            des Datensatzes, für den dieses dynamische
+            Attribut definiert ist. Der Datensatz ist in der
+            Datenstruktur zu finden, die mit Tabellennummer
+            eindeutig beschrieben ist und ist zusammen mit
+            ID_Zeitraum eindeutig zu ermitteln.
+
+            Warnung! Datenstrukturen, die keine eindeutige
+            Datensatz-ID mitführen, können keine dynamischen
+            Attribute haben (z.B. Teilrelationen_Type).
+            Zuvor müssten diese Strukturen um ein
+            ID_[Typname])-Feld erweitert werden.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Lang" type="husstDV:Lang_Type" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>optionale Sprachkennung des Wertes</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Wert" type="husstDV:blobString" maxOccurs="1" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Sprachtexte_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Für sprachalternative Texte wird statt ihres Textes eine
+        ID_Sprachtext als Verweis auf die neue Tabelle
+        Sprachtexte hinterlegt. Über ID_Sprachtext und der genau
+        zwei Zeichen langen Sprachkennung kann dann der Text in
+        der Tabelle Sprachtexte ermittelt werden.
+
+        Sprachtexte_Type bietet die Möglichkeit, identische Text-Bundle über die gleiche
+        Menge an Sprachkennungen nur einmal in der Datenbank abzulegen und
+        damit das Datenvolumen der Gesamtdatenmenge zu reduzieren. Würde der
+        eigentliche Text selbst noch über eine weitere Referenzstufe sprach-
+        und bedeutungslos in einer Texttabelle hinterlegt, wäre die
+        Einsparung vermutlich einfacher zu realisieren und in der Summer
+        vermutlich größer.
+
+        Sprachtexte sind innerhalb des Datenpaketes
+        allgemeingültig definiert und sind nicht über eine
+        ID_Zeitraum-Eigenschaft versioniert. Ihre IDs sind nicht
+        persistent denn sie haben nur innerhalb des Datenpaketes
+        eine referenzierende Bedeutung.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Sprachtext"/>
+          <api:field name="Lang"/>
+        </api:primekey>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ID_Sprachtext" type="xs:string" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Eindeutiger Schlüssel für den logischen Inhalt
+            des Textes der unter dieser Nummer ggf. in verschiedenen Sprachen
+            abgelegt ist.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Lang" type="husstDV:Lang_Type" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Sprache, für die der Text abgelegt ist.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Text" type="xs:string" maxOccurs="1" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Tabelleninfo_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Erweitertert die XML-Sturktur um Informationen über
+        die Abbildung der Daten in ein relationales Datenmodell.
+        Im Wesentlichen dokumentiert die Struktur zur Zeit die fest definierte
+        Beziehung zwischen dem Tabellen-Namen und der persistenten und
+        eindeutigen numerischen Abbildung als Tabellennummer.
+        Außerdem stellt sie den Bezug zum Namen der Xml-Datenstruktur her.
+        Falls künftig noch weitere Strukturinformationen benötigt werden, ist an
+        die Erweiterung des Tabelleninfo_Type zu denken.
+
+        Damit wird die in
+        &lt;xs:annotation&gt;&lt;appinfo&gt;&lt;tablenumber&gt;...
+        definierte Tabellennummer für nachfolgende Prozesse in jeder
+        Datenmenge hinterlegt.
+
+        Die numerische Abbildung einer Struktur wird als Schlüsselelement für
+        den Zugriff auf Datenstrukturen benötigt, deren Elemente sich auf
+        mehrere Elternstrukturen beziehen können.
+        Damit wird es möglichen, diese Beziehung in relationen DBMS performant
+        implementieren zu können. Wegen der spezifischen Verwendung für
+        relationen DBMS wird bewusst der Begriff Tabellennummer verwendet,
+        der ansonsten in der XML-Repräsentation der Daten als Fremdkörper
+        wirkt.
+        Beispiel für die Verwendung ist der DynAttributWert_Type bei dem die
+        Tabellennummer als Attribut im Primärschlüssel der Struktur
+        vorkommt.
+
+        Tabellennummern_Type ist eine Metainformationsstruktur.
+        Für die XML-Repräsentanz der Daten spielt sie keine Rolle und muss dort
+        auch nicht eingetragen werden. In der XML-Dartstellung werden die
+        referenzierten Daten nicht getrennt von ihrer Hauptinformation
+        abgelegt sondern bilden noch eine Einheit.
+        Für die Umwandlung in eine DB-Struktur, die diese Tabellennummern
+        benutzt, ist dagegen zwingend vorgeschrieben, mindestens die
+        Tabellennummern zu dokumentieren, die in den Daten verwendet werden.
+        Die komplette Auflistung der Tabellenmmnern einer Struktur wird für
+        DB-Repräsentationen empfohlen.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="Tabellennummer"/>
+        </api:primekey>
+        <index name="Idx_Tabinfoname">
+          <field name="Tabellenname"/>
+        </index>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Tabellenname" type="xs:string" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Name der Tabelle in einer relationen DB
+            Abbildung dieser Datenstruktur. Zum Beispiel
+            'Sorten' für die Elemente der Sorten_Type
+            Struktur. Er entspricht dem Xml-Attribut "name" der Element-Definition der
+            Struktur in der XML-Datenmenge. Zum Beispiel
+            &lt;xs:element name="Sorten"
+            type="husstDV:Sorten_Type" nillable="true" /&gt;
+            oder auch
+            &lt;xs:element name="SortenTarifarten"
+            type="husstDV:SortenTarifarten_Type" nillable="true" /&gt;
+
+            Die Schreibweise des Names entspricht dem Elementname, der in der
+            Xml-Datenmenge verwendet wird.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Tabellennummer" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Persistente und eindeutigen numerische
+            Abbildung. Die Tabellennnummer wird in dieser
+            Struktur als
+            &lt;xs:annotation&gt;&lt;appinfo&gt;&lt;tablenumber
+            hinterlegt und gilt als Teil der
+            Strukturdefinition.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Strukturname" type="xs:string" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Name der Xml-Datenstruktur, die von dieser
+            Tabelle abgebildet wird.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DynAttribut_Subtype">
+    <xs:annotation>
+      <xs:documentation>
+        Der Subtyp DynAttribut_Subtype dient der Definition von
+        dynamischen Attributen als mögliche Erweiterung für die
+        Xml-Darstellung der Daten. Der Subtyp wird nicht 1:1 für
+        eine Abbildung auf ein relationales Datenbankmodell
+        verwendet.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Name" type="xs:string" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Wert" type="husstDV:DynAttributWert_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+    <xs:attribute name="dtyp" type="husstDV:DynAttributTyp_Type"/>
+  </xs:complexType>
+  
+  <xs:complexType name="DynAttributWert_Subtype">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:schema name="Basis"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:simpleContent>
+      <xs:extension base="husstDV:blobString">
+        <xs:attribute name="lang" type="husstDV:Lang_Type"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>

--- a/Version 3/3.8.0/HUSST_DvBasis_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_DvBasis_3_8_0.xsd
@@ -1861,7 +1861,7 @@
           <xs:documentation>VersionMajor muss sich immer bei Inkompatibilitäten zur Vorgängerversion ändern.</xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="VersionMinor" type="husstDV:INT4" maxOccurs="1" minOccurs="1" default="7">
+      <xs:element name="VersionMinor" type="husstDV:INT4" maxOccurs="1" minOccurs="1" default="8">
         <xs:annotation>
           <xs:documentation>VersionMinor zählt kompatible Anpassungen.</xs:documentation>
         </xs:annotation>
@@ -1872,7 +1872,7 @@
         </xs:annotation>
       </xs:element>
       <xs:element name="Status" type="husstDV:VersionStatus_Type" default="Release" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="Aenderungsdatum" type="husstDV:DateCompact" default="2025-01-15" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="Aenderungsdatum" type="husstDV:DateCompact" default="2025-06-16" maxOccurs="1" minOccurs="0"/>
       <xs:element name="Aenderungsautor" type="xs:string" default="HUSST-Arbeitsgruppe" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>

--- a/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
@@ -4985,6 +4985,7 @@
           <api:field name="ID_Streckenverlauf"/>
           <api:field name="ID_Zeitraum"/>
         </api:uniquekey>
+        <api:schema name="Tarifstrecken"/>
       </xs:appinfo>
     </xs:annotation>
     <xs:sequence>
@@ -5048,6 +5049,7 @@
           * wenn ID_TarifartStrecke an der Relation nicht gesetzt ist, dann hat diese Zuordnung  keine Auswirkung,
           * das Vertriebsgerät muss die durch die Streckenverläufe definierten Verbindungen parallel in der Streckenlogik suchen,
           * das Vertriebsgerät muss parallel in der normalen Streckenlogik (kürzester Weg) suchen, wenn kein Streckenverlauf zu der Relation zugewiesen ist.
+        Optional kann ein alternativer Rückweg im Streckentarif zugeordnet sein.  
       </xs:documentation>
       <xs:appinfo>
         <api:primekey>
@@ -5061,8 +5063,9 @@
     <xs:sequence>
       <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
       <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
-      <xs:element name="ID_Streckenverlauf" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
       <xs:element name="ID_Relation" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckenverlauf" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckenverlauf_Rueck" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
   

--- a/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
@@ -864,13 +864,13 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="ID_StreckencodeVerlauf" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+      <xs:element name="ID_Streckenverlauf" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
         <xs:annotation>
           <xs:documentation>
-            Die ID_StreckencodeVerlauf ermöglicht das matchen von einer Relation zu einer festgelegten Verbindung in Streckentarifen.
-             * wenn ID_TarifartStrecke nicht gesetzt ist, dann hat ID_StreckencodeVerlauf keine Auswirkung,
-             * das Vertriebsgerät muss die durch den StreckencodeVerlauf definierte Strecke parallel in der Streckenlogik suchen, wenn ID_StreckencodeVerlauf gesetzt ist,
-             * das Vertriebsgerät muss parallel in der normalen Streckenlogik (kürzester Weg) suchen, wenn ID_StreckencodeVerlauf nicht gesetzt ist.
+            Die ID_Streckenverlauf ermöglicht das Matchen von einer Relation zu einer festgelegten Verbindung in Streckentarifen.
+             * wenn ID_TarifartStrecke nicht gesetzt ist, dann hat ID_Streckenverlauf keine Auswirkung,
+             * das Vertriebsgerät muss die durch den Streckenverlauf definierte Strecke parallel in der Streckenlogik suchen, wenn ID_Streckenverlauf gesetzt ist,
+             * das Vertriebsgerät muss parallel in der normalen Streckenlogik (kürzester Weg) suchen, wenn ID_Streckenverlauf nicht gesetzt ist.
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -4978,15 +4978,15 @@
     </xs:sequence>
   </xs:complexType>
   
-  <xs:complexType name="StreckencodeVerlauf_Type">
+  <xs:complexType name="Streckenverlauf_Type">
     <xs:annotation>
       <xs:documentation>
-        Ein richtungsgebundener Verlauf von Streckencodes, welcher eine Verbindung über verschiedene Streckencodes als Vias darstellt.
+        Ein richtungsgebundener Verlauf von Strecken, welcher eine Verbindung über mehrere explizit definierte Brechpunkte darstellt.
       </xs:documentation>
       <xs:appinfo>
         <api:primekey>
-          <api:field name="ID_Streckencode"/>
-          <api:field name="ID_StreckencodeVerlauf"/>
+          <api:field name="ID_Strecke"/>
+          <api:field name="ID_Streckenverlauf"/>
           <api:field name="ID_Zeitraum"/>
         </api:primekey>
         <api:schema name="Tarifstrecken"/>
@@ -4995,19 +4995,19 @@
     <xs:sequence>
       <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
       <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
-      <xs:element name="ID_StreckencodeVerlauf" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
-      <xs:element name="ID_Streckencode" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
-      <xs:element name="IstViapunkt" type="xs:boolean" maxOccurs="1" minOccurs="1">
+      <xs:element name="ID_Streckenverlauf" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Strecke" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="IstStartBrechpunkt" type="xs:boolean" maxOccurs="1" minOccurs="1">
         <xs:annotation>
           <xs:documentation>
-            Gibt an, ob der Streckencode eine Relevanz bei der Streckensuche hat.
+            Gibt an, ob der Start-Streckencode der Strecke ein expliziter Brechpunkt ist und damit maßgeblich den Verlauf bestimmt.
           </xs:documentation>
         </xs:annotation>
       </xs:element>
       <xs:element name="SortOrder" type="husstDV:INT4" minOccurs="1" maxOccurs="1">
         <xs:annotation>
           <xs:documentation>
-            Reihenfolge der Streckencodes in der sie durchfahren werden.
+            Reihenfolge der Strecken in der sie durchfahren werden.
           </xs:documentation>
         </xs:annotation>
       </xs:element>
@@ -5155,7 +5155,8 @@
   <xs:element name="GleichstellungTarifart" type="husstDV:GleichstellungTarifart_Type"/>
   
   <xs:element name="Gleichstellung" type="husstDV:Gleichstellung_Type"/>
-  
+
+  <xs:element name="Streckenverlauf" type="husstDV:Streckenverlauf_Type"/>
   <!--Wurzel -->
   
   <xs:element name="OePVTarifDB" type="husstDV:OePVTarifDB_Type"/>
@@ -5221,6 +5222,7 @@
       <xs:element ref="husstDV:SortengruppenErmittlungen"/>
       <xs:element ref="husstDV:Strecke"/>
       <xs:element ref="husstDV:Streckencode"/>
+      <xs:element ref="husstDV:Streckenverlauf"/>
       <xs:element ref="husstDV:Streckenzuordnung"/>
       <xs:element ref="husstDV:TagesartMerkmalElemente"/>
       <xs:element ref="husstDV:Tagesarten"/>

--- a/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
@@ -1,0 +1,5284 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:husstDV="http://husst.de/Versorgungsdaten/3_8_0"
+           xmlns:api="http://www.husst.de/Appinfo/3_8_0"
+           targetNamespace="http://husst.de/Versorgungsdaten/3_8_0"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <xs:include schemaLocation="./HUSST_DvBasis_3_8_0.xsd"/>
+
+  <xs:annotation>
+    <xs:documentation>
+      HUSST Versorgungsdaten - Schemata: Tarif, Angebot (verwendet Basisversorgungsdaten)
+      Version: 3.8.0
+
+      Mehr Informationen:
+      - https://husst.de/
+      - https://github.com/HUSST-de/HUSST
+
+      Lizensiert unter CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:simpleType name="ZuordnungRelCodeGrp_Type">
+    <xs:annotation>
+      <xs:documentation>s. Verwendung in den ZusatzSorten_Type</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:Char">
+      <xs:enumeration value="S">
+        <xs:annotation>
+          <xs:documentation>StartRelCode</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="Z">
+        <xs:annotation>
+          <xs:documentation>ZielRelCode</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="R">
+        <xs:annotation>
+          <xs:documentation>StartZielRelCode</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ZusSorteAnbindung_Type">
+    <xs:annotation>
+      <xs:documentation>s. Verwendung in den ZusatzSorten_Type</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:Char">
+      <xs:enumeration value="V">
+        <xs:annotation>
+          <xs:documentation>Vorlauf</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="N">
+        <xs:annotation>
+          <xs:documentation>Nachlauf</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="H">
+        <xs:annotation>
+          <xs:documentation>Hauptlauf</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="U">
+        <xs:annotation>
+          <xs:documentation>Richtungsungebunden</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="Sammelbeleg_Type">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="true">
+        <xs:annotation>
+          <xs:documentation>ein Fahrschein für n Personen</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="false">
+        <xs:annotation>
+          <xs:documentation>n Fahrscheine für n Personen</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="auswahl">
+        <xs:annotation>
+          <xs:documentation>
+            Bediener entscheidet, ob ein oder n Fahrscheine
+            gedruckt werden, bei n&gt;1
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_RelationenberechnungsregelungHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Relationenberechnungsregelung kleiner 1000
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>
+            Standard.
+            Alle Teilrelationen sind gleichwertig und haben verschiedene Tarifarten und oder Tarifgebiete.
+            Die gewählte Sorte entscheidet, welche Teilrelation genutzt wird.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>
+            Sortorder1
+            Die Teilrelation mit Sortorder 1 muss bepreist werden, die anderen Teilrelationen werden zusätzlich registriert.
+            Die Teilrelationen können aus verschiedenen Tarifgebieten sein und / oder verschiedene Tarifarten aufweisen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>
+            AdditionPreise
+            Die Preise aller Teilrelationen werden addiert, es werden alle Teilrelationen registriert.
+            Die Teilrelationen können aus verschiedenen Tarifgebieten sein und / oder verschiedene Tarifarten aufweisen.
+            Für die Bepreisung muss eine Sortengruppe zur Verfügung stehen, in der jeweils eine Sorte zu mindestens einer Teilrelation passt.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>
+            AdditionPreisstufen
+            Die gewählte Sorte entscheidet über ihre Tarifart(en), welche Teilrelation(en) für die Preisfindung und die Registrierung verwendet werden.
+            Nicht passende Teilrelationen werden ignoriert.
+            Damit ist sichergestellt, dass alle verwendeten Teilrelationen aus einem Tarifgebiet stammen.
+            Die Preisstufen der Teilrelationen werden addiert und dazu der Preis der Sorte ermittelt, alle diese Teilrelationen werden
+            registriert.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Relationenberechnungsregelung_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Relationenberechnungsregelung ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_RelationenberechnungsregelungHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_RelationendruckregelungHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Relationendruckregelung kleiner 1000
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>
+            Ein.
+            Es wird ein Ticket gedruckt.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>
+            Alle
+            Es wird ein Ticket pro Telrelation gedruckt.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>
+            Tarifgebiet.
+            Alle Teilrelationen eines Tarifgebietes werden mit je einem Ticket gedruckt.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Relationendruckregelung_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Relationendruckregelung ist entweder eine von HUSST vordefinierte Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_RelationendruckregelungHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="KA_Kundentyp_CODE_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Aus der KA (XML-Schema_KVP_DL_PV.xsd):
+        Der Kundentyp_CODE klassifiziert Kunden bzgl.
+        typischer tarifrelevanter
+        Kundengruppen des OePV.
+        BOM 6-38
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT1">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Erwachsener</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Kind</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Student</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="5">
+        <xs:annotation>
+          <xs:documentation>Behinderter</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="6">
+        <xs:annotation>
+          <xs:documentation>Sehbehinderter</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="7">
+        <xs:annotation>
+          <xs:documentation>Hörgeschädigter</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="8">
+        <xs:annotation>
+          <xs:documentation>Arbeitsloser/Sozialhilfeempfänger</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="9">
+        <xs:annotation>
+          <xs:documentation>Personal</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="10">
+        <xs:annotation>
+          <xs:documentation>Militärangehöriger</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="19">
+        <xs:annotation>
+          <xs:documentation>Schüler</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="20">
+        <xs:annotation>
+          <xs:documentation>Azubi</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="25">
+        <xs:annotation>
+          <xs:documentation>Senior</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="KA_Profil_CODE_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Aus der KA (XML-Schema_KVP_DL_PV.xsd):
+        Typ: klassifiziert Kunden, Objekte, etc. bzgl.
+        tarifrelevanter Gruppen
+        des OePV BOM 6_45
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT1">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Erwachsener</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Kind</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Student</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="5">
+        <xs:annotation>
+          <xs:documentation>Behinderter</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="6">
+        <xs:annotation>
+          <xs:documentation>Sehbehinderter</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="7">
+        <xs:annotation>
+          <xs:documentation>Hörgeschädigter</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="8">
+        <xs:annotation>
+          <xs:documentation>Arbeitsloser/Sozialhilfeempfänger</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="9">
+        <xs:annotation>
+          <xs:documentation>Personal</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="10">
+        <xs:annotation>
+          <xs:documentation>Militärangehöriger</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="19">
+        <xs:annotation>
+          <xs:documentation>Schüler</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="20">
+        <xs:annotation>
+          <xs:documentation>Azubi</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="25">
+        <xs:annotation>
+          <xs:documentation>Senior</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="KA_ServiceKlasse_CODE_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Aus der KA (XML-Schema_KVP_DL_PV.xsd):
+        Der ServiceKlasse_CODE klassifiziert Servicequalitaeten der
+        Transportdienstleistung.
+        Haeufigstes Beispiel ist die Unterscheidung in 1. und 2.
+        Klasse.
+        BOM 6-49
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT1">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>1. Klasse</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>2. Klasse</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="KA_TransportmittelKategorie_CODE_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Aus der KA (XML-Schema_KVP_DL_PV.xsd):
+        Der TransportmittelKategorie_CODE klassifiziert Arten von
+        Transportdienstleistungen im Sinne einer Qualitaetsklasse, z.B. "IC/EC", "ICE"
+        bei
+        der Deutschen Bahn. Diese Kategorien sind
+        "marketinggetrieben" mit Auswirkungen auf
+        den Preis und daher produktspezifisch.
+        BOM 6-60
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT1">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Linienbus im Stadtverkehr</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Metro/U-Bahn/S-Bahn</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>Straßenbahn/TRAM</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="10">
+        <xs:annotation>
+          <xs:documentation>ICE</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="11">
+        <xs:annotation>
+          <xs:documentation>Überlandbus/Regionalbus</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="20">
+        <xs:annotation>
+          <xs:documentation>IC</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="29">
+        <xs:annotation>
+          <xs:documentation>Regionalexpress</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="30">
+        <xs:annotation>
+          <xs:documentation>Expressbus</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="31">
+        <xs:annotation>
+          <xs:documentation>Flughafenzubringer</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="32">
+        <xs:annotation>
+          <xs:documentation>Verbundnahverkehr</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="33">
+        <xs:annotation>
+          <xs:documentation>Verbundnahverkehr ohne Kurzstrecke</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="34">
+        <xs:annotation>
+          <xs:documentation>SPNV</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="KA_RabattParameter_CODE_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Aus der KA:
+        Der RabattParameter_CODE kennzeichnet einen Rabbatierungstyp bzw. Ermäßigungstyp.
+        BOM 6-71
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT1">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>Keine Ermäßigung</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>
+            prozentuale Ermäßigung
+            Level-1
+            (z.B. Bahncard 25)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>
+            prozentuale Ermäßigung18
+            Level-2
+            (z.B. Bahncard 50)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>
+            prozentuale Ermäßigung
+            Level-3
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>
+            prozentuale Ermäßigung
+            Level-4
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="5">
+        <xs:annotation>
+          <xs:documentation>
+            prozentuale Ermäßigung
+            Level-5
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="6">
+        <xs:annotation>
+          <xs:documentation>
+            Ermäßigung auf Basis
+            gefahrener Kilometer
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="46">
+        <xs:annotation>
+          <xs:documentation>
+            Ermäßigung des
+            Ticketkaufs mit
+            KA-Bezahlberechtigung um 25%
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <!--Allgemein -->
+  
+  <xs:complexType name="Tarifgebiete_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Tarifgebiet ist eine logische Einheit, die alle
+        Tarifelemente eines Tarifgebers
+        zusammenfasst
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Tarifgebiet"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="BezeichnungKurz" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Erstellungsdatum" type="husstDV:DateTimeCompact" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Version" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Tarifpunkte_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Tarifpunkt"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Ein Tarifpunkt dient der Zusammenfassung (ein oder) mehrerer Haltestellen aus Tarifsicht (weil Fahrten zu
+        diesen bzw. von diesen Haltestellen immer zum gleichen Preis führen). Ein Tarifpunkt hat eine
+        Nummer und ggf. auch einen Namen. Außerdem ist ein Tarifpunkt genau einem Tarifgebiet
+        zugeordnet. Tarifpunkte werden zum Aufdruck auf Fahrscheinen benötigt um eine Kontrolle der
+        räumlichen Gültigkeit zu ermöglichen. In vielen Tarifsystemen haben Tarifpunkte Namen wie: Zone
+        oder Ring.
+        Tarifpunkte bilden Endpunkte in der Tarifmatrix: Von-Tarifpunk -&gt; Nach-Tarifpunkt -&gt; Preisstufe
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifpunkt" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifpunkttyp" type="husstDV:ID_Tarifpunkttyp_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            1=Zone/Wabe/Ring/Tarifpunkt
+            2=Wabentyp
+            (Zusammenfassung mehrere Elemente von Typ 1)
+            3=Tarifhaltestelle
+            4=Ortsteil (in seiner Funktion als Tarifpunkt)
+            5=Ort
+            (Zusammenfassung mehrere Ortsteile)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="BezeichnungDruck" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_TarifpunktReferenz" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Tarifpunktmengen_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Tarifpunktmenge"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Eine Tarifpunktmenge umfasst die Menge der ihr zugeordneten Tarifpunkte in Form von TarifpunktmengeElementen.
+        Über eine Tarifpunktmenge können somit bspw. alle Zonen eines Fahrtverlaufs oder alle erlaubten Zonen zu einer ausgewählten Verbindung abgebildet werden.
+
+        RaeumlicheGueltigkeits-Elemente und SortengruppenErmittlungen können auf Tarifpunktmengen verweisen.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifpunktmenge" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="TarifpunktmengeElemente_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Eintrag in einer geordneten Menge von Tarifpunkten.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_TarifpunktmengeElement"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_TarifpunktmengeElement" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Tarifpunktmenge" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Tarifpunkt" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="SortOrder" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Relationscodes_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Relationscodes fassen Tarifpunkte mehrerer
+        Tarifgeber zusammen. Damit können
+        einzelnen Orten/Haltestellen
+        unterschiedlich viele Tarifpunkte
+        unterschiedlicher Tarifgeber
+        zugeordnet werden
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Relcode"/>
+          <api:field name="ID_Zeitraum"/>
+          <api:field name="ID_Tarifpunkt"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relcode" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifpunkt" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Relationscodegruppen_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Zusammenfassung von Relationscodes bspw. für City Option
+        unter einer Gruppennummer innerhalb eines ID_Relcodegruppentyps
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Relcodegruppe"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relcodegruppentyp" type="husstDV:ID_Relcodegruppentyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relcodegruppe" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Gruppennummer" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relcode" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="RaeumlicheGueltigkeit_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Definition der räumlichen Gültigkeit
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_RaeumlicheGueltigkeit"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_RaeumlicheGueltigkeit" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Eindeutige Datensatz-ID innerhalb eines Zeitraumes
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ID_Tarifpunktmenge" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Referenz auf eine Tarifpunktmenge.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_GueltigkeitsraumOriginaer" type="husstDV:blobString" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Die originäre räumliche Gültigkeit auf einem KA Ticket.
+            Wird als ganzes TLV abgebildet, beginnend mit dem TAG 'DC'
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_GueltigkeitsraumAlternativ" type="husstDV:blobString" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Die alternative räumliche Gültigkeit auf einem KA Ticket.
+            Wird als ganzes TLV abgebildet, beginnend mit dem TAG 'D9'
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Relationen_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Relation auf Relationscode Ebene
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Relation"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relation" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_RelcodeStart" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_RelcodeZiel" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="SortOrder" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Variantenzählung - Bestimmt die Reihenfolge der
+            Vias in
+            der Auswahl
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="GegenrichtungLiegtVor" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Vertriebswege" type="husstDV:ID_Vertriebswege_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schränkt die Verwendung des Elements auf die angegebenen Vertriebswege ein.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Via" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Nummer der Viatexte für diese Verbindung. Verweis auf Vias.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Berechnungsregelung" type="husstDV:ID_Relationenberechnungsregelung_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Regelt die Verwendung konkurrierender Teilrelationen (gleiche ID_Tarifgebiet, ID_Tarifart) zur Preisberechnung und Registrierung.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Druckregelung" type="husstDV:ID_Relationendruckregelung_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Regelt die Verwendung konkurrierender Teilrelationen für den Ausdruck von Tickets.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_TarifartStrecke" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Die ID_TarifartStrecke ermöglicht oder verhindert eine parallele Suche in den Streckentarifen.
+             * das Vertriebsgerät muss parallel in der Streckenlogik suchen, wenn ID_TarifartStrecke gesetzt ist,
+             * das Vertriebsgerät darf nicht in der Streckenlogik suchen, wenn ID_TarifartStrecke leer bzw. nicht angegeben ist, unabhängig davon, ob die Relation mit Teilrelationen verknüpft ist, oder nicht.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_StreckencodeVerlauf" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Die ID_StreckencodeVerlauf ermöglicht das matchen von einer Relation zu einer festgelegten Verbindung in Streckentarifen.
+             * wenn ID_TarifartStrecke nicht gesetzt ist, dann hat ID_StreckencodeVerlauf keine Auswirkung,
+             * das Vertriebsgerät muss die durch den StreckencodeVerlauf definierte Strecke parallel in der Streckenlogik suchen, wenn ID_StreckencodeVerlauf gesetzt ist,
+             * das Vertriebsgerät muss parallel in der normalen Streckenlogik (kürzester Weg) suchen, wenn ID_StreckencodeVerlauf nicht gesetzt ist.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Vias_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Gesamt Relationsinformation
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Via"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Via" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Text zur Auswahl der Variante, Teilstrecken
+            mit '*' getrennt
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungDruck" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Drucktext, Teilstrecken mit '*' getrennt
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungRueck" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Text zur Auswahl der Variante in der
+            Rückrichtung, Teilstrecken mit '*' getrennt
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungRueckDruck" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Drucktext in der Rückrichtung,
+            Teilstrecken mit '*' getrennt
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Relationszuordnungen_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Verknüpft Relationen und Teilrelationen
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Relationszuordung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:uniquekey name="Uix_Relationszuordnungen">
+          <api:field name="ID_Teilrelation"/>
+          <api:field name="ID_Relation"/>
+          <api:field name="ID_Relationszuordung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:uniquekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relationszuordung" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relation" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Teilrelation" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="SortOrder" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Teilrelationen_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Relation (und Teilrelation) auf Tarifpunkt Ebene
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Teilrelation"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Teilrelation" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifart" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_TarifpunktStart" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="TarifpunktbezeichnungStart" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_TarifpunktZiel" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="TarifpunktbezeichnungZiel" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Die ID_Tarifgebiet bleibt als retundante Information erhalten.
+            Sie muss aber mit der ID_Tarifgebiet der Preisstufe übereinstimmen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Preisstufe" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Preisquelle" type="husstDV:ID_Preisquelle_Type" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="ID_Komfortklasse" type="husstDV:ID_Komfortklasse_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Hinweis zur Komfortklasse (1.Klasse/2.Klasse etc).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="AlternativePreisGruppe" type="husstDV:INT4" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="EinnahmeAufteilung" type="xs:string" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="ViabezeichnungDruck" type="xs:string" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            alternativer Via-Drucktext, hat Vorrang vor dem
+            Drucktext des Via-Datensatzes
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ViabezeichnungRueckDruck" type="xs:string" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            alternativer Via-Drucktext für den umgekehrte
+            Streckenverlauf, hat Vorrang vor dem
+            Drucktext_Rueck des
+            Via-Datensatzes. Wenn
+            ViaDrucktext_Rueck leer ist, aber
+            ViaDrucktext
+            gefüllt hat ViaDrucktext Vorrang vor
+            Drucktext_Rueck
+            bzw. Drucktext des
+            Via-Datensatzes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_RaeumlicheGueltigkeit" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Verweis auf eine Definition für die räumliche
+            Gültigkeit.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ID_RaeumlicheGueltigkeit_Rueck" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Optionale Referenz auf eine Tarifpunktmenge für den Rückweg.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Linie" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Referenz der zugrunde liegenden Information zu
+            einer Datenmenge des Tarifgebers.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Nachbarhaltestellen_Type">
+    <xs:annotation>
+      <xs:documentation>Zur Definition von Kurzstrecken o.ä..(s. ID_Nachbarhaltestellenbeziehung)
+        Eine Nachbarhaltestellenbeziehung kann über ID_OrtspunktVon und ID_OrtspunktNach erfolgen
+        oder über ID_OrtspunktVon und Zahlgrenze. Es muss entweder ID_OrtspunktNach oder Zahlgrenze
+        gefüllt sein. Wenn beides gefüllt ist, gelten beide Bedingungen zeitgleich. (Es gilt auf der
+        Strecke von ID_OrtspunktVon nach ID_OrtspunktNach, wenn die Zahlgrenze nicht überschritten
+        ist.) Die Nachbarhaltestellen werden in der Verkaufslogik bei der Anzeige der Vias vor die
+        Relationen sortiert.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Nachbarhaltestelle"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:uniquekey name="Uix_Nachbarhaltestellen">
+          <api:field name="ID_OrtspunktVon"/>
+          <api:field name="ID_OrtspunktNach"/>
+          <api:field name="ID_Zeitraum"/>
+          <api:field name="ID_Bediengebiet"/>
+          <api:field name="ID_Nachbarhaltestellenbeziehung"/>
+          <api:field name="ID_Via"/>
+          <api:field name="ID_Tarifart"/>
+          <api:field name="Zahlgrenzen"/>
+          <api:field name="ID_Zahlgrenzentyp"/>
+        </api:uniquekey>
+        <api:schema name="Angebot"/>
+        <api:remarks>
+          In Daisy (Entwicklungsversion) sollte beachtet werden, die Nachbarhaltestellen in Angebot-
+          und Tariftabellen zu trennen.
+          Vorbild: Relationen und Teilrelationen
+        </api:remarks>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Nachbarhaltestelle" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Bediengebiet" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bediengebiet, in dessen Kontext die Nachbarbeziehung definiert ist .</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Nachbarhaltestellenbeziehung" type="husstDV:ID_Nachbarhaltestellenbeziehung_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Art der Nachbarbeziehung.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_OrtspunktVon" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>ID_Ortspunkt, für die eine Nachbarbeziehung definiert wird (kleinere
+            ID des Paares, bei Halbmatrix).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_OrtspunktNach" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>ID_Ortspunkt, für die eine Nachbarbeziehung definiert wird (größere ID
+            des Paares, bei Halbmatrix)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="SortOrder" type="husstDV:INT4" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="ID_Via" type="husstDV:INT4" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="ID_Tarifart" type="husstDV:INT4" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Tarifgebiet, für das eine Nachbarhaltestelle definiert wird.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Preisstufe" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Zuordnung Preisstufe</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Zahlgrenzen" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Gibt den Wert an vom Typ des Zahlgrenzentyps.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Zahlgrenzentyp" type="husstDV:ID_Zahlgrenzentyp_Type" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Gibt den Typ an, der die Zahlgrenzen definiert.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefZahlgrenzentyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Zahlgrenzentyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Zahlungsarten definieren ein Verfahren, mit dem eine Sorte bezahlt werden
+        kann. Siehe auch ID_Zahlungsarten_Type bzw. ID_ZahlungsartenHUSST_Type.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Zahlgrenzentyp" type="husstDV:ID_Zahlgrenzentyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung der Zahlgrenze.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_Zahlgrenzentyp_Type">
+    <xs:annotation>
+      <xs:documentation>Die ID_Zahlgrenzentyp ist entweder eine von HUSST vordefinierter Zahl
+        kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_ZahlgrenzentypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_ZahlgrenzentypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>Die HUSST definiert ID_Zahlgrenzentyp kleiner 1000</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Anzahl Haltestellen</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Tarifkilometer</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Radius (Luftlinie)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:complexType name="Preisstufendirektwahl_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Definition von Haltestellengruppen für
+        Kurzstrecken/Zahlgrenzen
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Preisstufendirektwahl"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Preisstufendirektwahl" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Datensatz-Schlüssel - eindeutig innheralb der ID_Zeitraum
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Direktwahlschluessel" type="xs:string" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schlüsselwert, über den die Pst-Direktwahl
+            gefunden wird. Projektspezifisch definiert.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Tarifart" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Tarifart (0=Allgemein, 1=Bartarif, 2=Zeittarif)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Preisstufe" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Zuordnung Preisstufe</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Text zur Anzeige der Preisstufendirektwahl
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungDruck" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Drucktext
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Relation" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Vertriebswege" type="husstDV:ID_Vertriebswege_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schränkt die Verwendung des Elements auf die angegebenen Vertriebswege ein.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <!--Produkte -->
+  
+  <xs:complexType name="Preisspalten_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die Preisspalte definiert die Währung der zugeordneten Preise und ermöglicht Preisvarianten.
+        Verschiedene Preisspalten für die gleiche Sorte, Währung und Preisstufe
+        ermöglichen die Bereitstellung alternativer Preise (z.B. Barzahlung vs. Bezahlung mit Kundenkarte)
+        oder den Ausweis von spezifischen Preisanteilen (z.B. Preisanteil Aufgabenträger).
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Preisspalte"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Preisspalte" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Waehrung" type="husstDV:ID_Waehrung_Type" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            ISO-Kennung (dezimal) der Währung -
+            außer EUR=999
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Preisspaltentyp" type="husstDV:ID_Preisspaltentyp_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Definiert den Verwendungszweck oder die Herkunft einer Preisspalte.
+            HUSST Standard=1
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Spaltenüberschrift
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungKurz" type="xs:string" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="Hinweis" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Info zur Preisspalte</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Preisstufen_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Preisstufe"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Definition der Preisstufen pro Tarifgebiet und Zeitraum</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Preisstufe" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Preisstufennummer" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="BezeichnungKurz" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="WegstreckeInMetern" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            durschnittliche Wegstrecke in Meter für
+            PKM (Personen-Kilometer)
+            Berechnung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Mwst" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Nummer des Mehrwertsteuersatzes
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="UpgradeStopp" type="xs:boolean" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Ein Preisupgrade kann bis zu einschließlich
+            dieser Preisstufe erfolgen.
+            Es können mehrere Stopps eingebaut sein.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="SortOrder" type="husstDV:INT4" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="KA_Preisstufe" type="husstDV:INT1" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="SortenTarifarten_Type">
+    <xs:annotation>
+      <xs:documentation>
+        N:M Zuordnung - Sorte / Tarifart
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Sorte"/>
+          <api:field name="ID_Tarifart"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Sorte" type="husstDV:INT4" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Nummer der Sorte, eindeutig über alle Tarifgebiete
+            innerhalb des ID_Zeitraum bzw. des Haupt-ID_Zeitraum
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Tarifart" type="husstDV:INT4" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Tarifart (siehe Hilfstabelle Tarifart)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Sorten_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Artikel/Produkte/Fahrscheintypen
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Sorte"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Sorte" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Nummer der Sorte, eindeutig über alle
+            Tarifgebiete und Tarifversionen
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Sortentyp" type="husstDV:ID_Sortentyp_Type" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Typ der Sorte
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schlüssel des Tarifgebers für diese Sorte
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungKurz" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Verwendung: Identifikation / optional Druck
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Verwendung: Identifikation / optional Druck
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Ausgaberegelung" type="husstDV:ID_Sortenausgaberegelung_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Hinweis zur Ausgabe der Sorte (Papierfahrschein / Elektronischer Fahrausweis etc.)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Druckregelung" type="husstDV:ID_Sortendruckregelung_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Steuert die Fahrscheinausgabe auf verschiedene Medien.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Layout" type="husstDV:blobString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Layoutdefinition für den Ausdruck des Produktes
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Vertriebswege" type="husstDV:ID_Vertriebswege_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schränkt die Verwendung der Sorte auf die angegebenen Vertriebswege ein.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Mwst" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zahlungsarten" type="husstDV:ID_Zahlungsarten_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schränkt die Verwendung der Sorte auf die angegebenen Zahlungsarten ein.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Komfortklasse" type="husstDV:ID_Komfortklasse_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Hinweis zur Komfortklasse (1.Klasse/2.Klasse etc).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Rabattklasse" type="husstDV:ID_Rabattklasse_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Hinweis zur Rabattklasse (BC25/BC50 ect.).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Fahrgasttyp" type="husstDV:ID_Fahrgasttyp_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Hinweis zum Fahrgasttyp (Erwachsener/Kind etc.).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Mindestpersonenanzahl" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Ab wievielen Personen darf der Fahrschein
+            verkauft werden
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Hoechstpersonenanzahl" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Bis zu wievielen Personen darf der Fahrschein
+            maximal verkauft werden
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_GueltigkeitszeitRegel" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Definiert die zeitliche Gültigkeit des Produktes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Preisfindung" type="husstDV:ID_Preisfindung_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Hinweis zur Preisfindung.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Reisetyp" type="husstDV:ID_Reisetyp_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Beschreibt den Typ der Reise (normale Fahrt, HinUndRück, Rundreise, ...)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungDruck" minOccurs="0" maxOccurs="1" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+            Drucktext Verwendung ist abhängig von der Layoutdefinition
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_ProdOrgID" type="husstDV:INT2" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            KA Produkt Organisationsnummer
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_ProdNr" type="husstDV:INT2" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>KA Produkt</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_Infotext" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="KA_Fahrgasttyp" type="husstDV:KA_Kundentyp_CODE_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>KA Fahrgasttyp</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_Verkehrsmittel" type="husstDV:KA_TransportmittelKategorie_CODE_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            KA Verkehrsmittel
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_Serviceklasse" type="husstDV:KA_ServiceKlasse_CODE_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            KA Serviceklasse
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Zusatzsorten_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Zusatzsorte"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:uniquekey name="Uix_Zusatzsorten">
+          <api:field name="ID_Sorte"/>
+          <api:field name="ZuordnungRelCodeGrp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:uniquekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Zusatzsorten sind Anschluss- und Anstossprodukte, die in Abhängigkeit von Preisstufe, bereits gewählter Sorte und Relation angeboten werden
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Zusatzsorte" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Sorte" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ZuordnungRelCodeGrp" type="husstDV:ZuordnungRelCodeGrp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Anbindung" type="husstDV:ZusSorteAnbindung_Type" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Zusatzsortentyp" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            (Bedeutung projektspezifisch.
+            MENT:1=Flächenanstoß, 2=Zusatzanstoß, 3=Streckenanstoß)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Preisstufe" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Fremdschlüssel zur Produktbildung - wenn angegeben,
+            wird diese Preisstufe fest zur Preisbestimmung verwendet.
+            Die Angabe hat Vorrang vor ID_PreisstufenGrenze.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_PreisstufeGrenze" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            wenn nicht vorhanden (und ID_Preisstufe nicht vorhanden) -
+            alle Preisstufen möglich sonst alle Preisstufen mit
+            ID_Preisstufe kleiner gleich ID_PreisstufeGrenze
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Hinweistext" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            z.B. für Zusatzinfo auf Quittungsausdruck – nicht
+            bei Direktverkauf!
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_SortengruppeHauptsorten" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Verweis auf SortenGruppe mit erlaubten Hauptsorten
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_RelcodegruppeStart" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Verweis auf RelCodeGruppe die erlaubte
+            RelCode_Start der Hauptrelation gruppiert = Vorlauf
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_RelcodegruppeZiel" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Verweis auf RelCodeGruppe die erlaubte
+            RelCode_Ziel der Hauptrelation gruppiert = Nachlauf
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Direktverkauf" type="xs:boolean" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            False="immer mit Hauptsorte",
+            True="Direktverkauf ohne Hauptsorte, falls Verkaufsort in
+            Gruppierung durch VerkaufsRelCode enthalten"
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Preise_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Preis"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:uniquekey name="Uix_Preise">
+          <api:field name="ID_Preisstufe"/>
+          <api:field name="ID_Sorte"/>
+          <api:field name="ID_Preisspalte"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:uniquekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Preise aller Sorten, abhängig von Zeitraum und Tarifgebiet, ggf. auch von Preisstufe, und Preisspalte</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Preis" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Sorte" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Die ID_Tarifgebiet bleibt als retundante Information erhalten.
+            Sie muss aber mit der ID_Tarifgebiet der Preisstufe übereinstimmen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Preisstufe" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Preisspalte" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            bisher: TarifgeberProduktNr
+            Schlüssel des Tarifgebers
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Preis" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Preis in kleinster Währungseinheit (z.b. Cent)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="PreisstufenbezeichnungKurz" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            optional: abweichende Preisstufenkurzbezeichnung
+            für Anzeige und Druck
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Preisstufenbezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            optional: abweichende Preisstufenbezeichnung
+            für Anzeige und Druck
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Mwst" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            optional: abweichende Mehrwertsteuerkennung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_PreisstufeReferenz" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            optional
+            Referenz auf die tatsächlich zu verwendende Preisstufe für
+            Druck
+            Anzeige
+            Registrierung
+            Gültigkeitsberechnung
+
+            Verwendung:
+            Wenn eine Tarifverbindung eine ID_Preisstufe x liefert, und die
+            Tarifbestimmungen definieren, dass
+            für dieses Sorte statt der ID_Preisstufe x ein Fahrschein mit der
+            Preisstufe y verkauft werden soll,
+            wird in ID_PreisstufeReferenz ein Verweis auf Preisstufe y
+            eingetragen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_GueltigkeitszeitRegel" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Definiert die zeitliche Gültigkeit des Produktes.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <!-- KA -->
+      <xs:element name="ID_RaeumlicheGueltigkeit" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Verweis auf eine Definition für die räumliche Gültigkeit.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_ProdOrgID" type="husstDV:INT2" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            KA Produkt Organisationsnummer
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_ProdNr" type="husstDV:INT2" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>KA Produkt</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_Rabatttyp" type="husstDV:KA_RabattParameter_CODE_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>KA Rabatttyp</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_Mitnahme1Typ" type="husstDV:KA_Profil_CODE_Type" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="KA_Mitnahme1MinAnzahl" type="husstDV:INT1" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="KA_Mitnahme1MaxAnzahl" type="husstDV:INT1" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="KA_Mitnahme2Typ" type="husstDV:KA_Profil_CODE_Type" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="KA_Mitnahme2MinAnzahl" type="husstDV:INT1" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="KA_Mitnahme2MaxAnzahl" type="husstDV:INT1" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="PreisstufenErmittlungen_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die PreisstufenErmittlungen dienen dazu, die zu berechenden Preisstufen für eine Sorte zu ermitteln.
+        Dabei orientiert sich die PreisstufenErmittlung an einer variablen Ermittlungseinheit (z.B. Minuten / Kilometer).
+        Die PreisstufenErmittlung ist eine alternative zur Ermittlung der Preisstufe über eine Teilrelation.
+        Die PreisstufenErmittlung hat hauptsächlich im Zusammenhang mit der SortengruppenErmittlung im MaaS-Bereich eine Relevanz.
+        Die ermittelte Preisstufe muss ggf. mehrfach berechnet werden.
+
+        Wenn die Menge an Ermittlungseinheiten in dem Rahmen von "Von" und "Bis" liegt,
+        wird die Anzahl der Schritte aufgerundet auf ganze Werte mal den Preis gerechnet.
+
+        Bsp.: Einheit Minuten, Von 0, Bis 90, Schritt 5, ID_Preisstufe 1
+        =&gt; Wenn 32 Minuten berechnet werden sollen, wird der Preis der ID_Preisstufe 1 7x berechnet.
+
+        Bsp. 2: Einheit Minuten, Von 90, Bis 180, Schritt 10, ID_Preisstufe 2
+        =&gt; Wenn 117 Minuten berechnet werden sollen, wird der Preis der ID_Preisstufe 2 3x berechnet.
+        Zusätzlich sind für den Zeitraum von 0 bis 90 Minuten weitere Preisstufen zu ermitteln. (z.B. aus Beispiel 1 die ID_Preisstufe 1 18x)
+
+        Bsp. 3: Einheit Kilometer, Von 0, Bis 100, Schritt 100, ID_Preisstufe 3
+        =&gt; Wenn 5 Kilometer berechnet werden sollen, wird der Preis der ID_Preisstufe 3 1x berechnet.
+        So kann ID_Preisstufe 3 allgemein nur 1x berechnet werden, da Schritt = Bis - Von ist.
+      </xs:documentation>
+
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_PreisstufenErmittlung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_PreisstufenErmittlung" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Preisstufe" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Ermittlungseinheit" type="husstDV:ID_Ermittlungseinheit_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Von" type="husstDV:INT4" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Incl.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bis" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Excl.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Schritt" type="husstDV:INT4" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schritt darf nicht größer als Bis - Von sein.
+            Schritt muss ein Teiler von Bis - Von sein =&gt; (Bis - Von) Modulo Schritt = 0.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Kann eine textuelle Beschreibung dieser Regel beinhalten. Diese ist nicht zur Verwendung von Vertriebsendgeräten vorgesehen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="SortengruppenErmittlungen_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die SortengruppenErmittlungen definieren Regeln zur Stukturierung von Tarifen in beliebig kleine Zeitperioden innerhalb eines Zeitraums.
+        Eine Zeitperiode wird dabei durch StartVon und -Bis Uhrzeit und der Tagesart definiert. DauerMax und der Überhang verfeinern diese Definition.
+      </xs:documentation>
+
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_SortengruppenErmittlung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_SortengruppenErmittlung" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Sortengruppe" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifpunktmenge" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Wenn gesetzt, definiert die Tarifpunktmenge zusätzlich zur zeitlichen eine räumliche Einschränkung.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_TagesartVon" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Wenn gesetzt, gilt diese Regel nur an den bestimmten Tagen.
+            Die gesetzte Tagesart gilt für die Uhrzeit StartVon.
+            Wenn nicht gesetzt gilt die Regel an allen Tagen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="StartVon" type="husstDV:UhrzeitMinuten" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Gibt eine Uhrzeit von dem an diese Zeitperiode gilt. Diese ist inklusiv zu betrachten.
+            Wenn StartVon und StartBis irrelevant sind, kann hier 00:00 Uhr eingetragen werden.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="StartBis" type="husstDV:UhrzeitMinuten" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Gibt eine Uhrzeit an der an diese Zeitperiode endet. Diese ist exklusiv zu betrachten.
+            Wenn StartBis kleiner ist als StartVon, dann ist StartBis am darauffolgenden Tag von StartVon.
+            Wenn StartVon und StartBis irrelevant sind, kann hier 24:00 Uhr eingetragen werden.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DauerMax" type="husstDV:DauerMinuten" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            DauerMax definiert die maximale Nutzungsdauer für die diese Zeitperiode gewählt werden kann.
+            Diese Dauer bezieht sich auf die Gesamtnutzung, auch wenn diese sich durch mehrere Zeitperioden zieht.
+            Diese Dauer ist inklusiv zu betrachten.
+
+            Bsp. Daten für Bsp. 1 und 2
+            - StartVon = 07:00 Uhr, StartBis = 17:00 Uhr, DauerMax = 48h, SortOrder = 1, ID_Sortengruppe = 1
+            - StartVon = 17:00 Uhr, StartBis = 07:00 Uhr, DauerMax = 48h, SortOrder = 2, ID_Sortengruppe = 2
+            - StartVon = 00:00 Uhr, StartBis = 24:00 Uhr, DauerMax = 144h, SortOrder = 3, ID_Sortengruppe = 3
+
+            Bsp 1: Nutzung von 01.01. 15:00 Uhr bis 03.01. 06:00 Uhr, Nutzungsdauer 39h
+            =&gt; ID_Sortengruppe 1 und 2 treten abwechselnd in Kraft, da diese Beiden durch die Sortorder bevorzugt werden
+            und den gesamten Nutzungszeitraum abdecken wird der 3. Datensatz nicht betrachtet.
+
+            Bsp 2: Nutzung von 01.01. 15:00 Uhr bis 05.01. 06:00 Uhr, Nutzungsdauer 63h
+            =&gt; ID_Sortengruppe 1 und 2 sind durch DauerMax ausgeschlossen -&gt; ID_Sortengruppe 3 tritt in Kraft
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Ueberhang" type="husstDV:DauerMinuten" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Der Überhang definiert eine Toleranz-Zeitspanne für die die Nutzung der Zeitperiode überschritten werden darf
+            ohne in eine neue Zeitperiode zu kommen.
+
+            Bsp. Daten für Bsp. 1 und 2
+            - StartVon = 07:00 Uhr, StartBis = 17:00 Uhr, Ueberhang = 2h, SortOrder = 1, ID_Sortengruppe = 1
+            - StartVon = 17:00 Uhr, StartBis = 07:00 Uhr, Ueberhang = 2h, SortOrder = 2, ID_Sortengruppe = 2
+
+            Bsp 1: Nutzung von 01.01. 05:00 Uhr bis 01.01. 08:00 Uhr
+            =&gt; ID_Sortengruppe 2 tritt in Kraft, da die 2h nach 07:00 Uhr nicht überschritten wurden.
+
+            Bsp 2: Nutzung von 01.01. 05:00 Uhr bis 01.01. 10:00 Uhr
+            =&gt; ID_Sortengruppe 2 tritt bis 07:00 Uhr in Kraft, da die 2h überschritten wurden. Ab 07:00 Uhr gilt ID_Sortengruppe 1.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="SortOrder" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Definiert aufsteigend die Reihenfolge, in der die Regeln ausgewertet werden.
+            Es gelten immer die Regeln, die als Erstes die komplette Nutzungsperiode abdecken.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Kann eine textuelle Beschreibung dieser Regel beinhalten. Diese ist nicht zur Verwendung von Vertriebsendgeräten vorgesehen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <!--Netz -->
+  
+  <xs:complexType name="OrtspunkteTG_Type">
+    <xs:annotation>
+      <xs:documentation>
+        tarifgebietspezifische-Attribute der Ortspunkte
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_OrtspunktTG"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:uniquekey name="Uix_OrtspunkteTG">
+          <api:field name="ID_Ortspunkt"/>
+          <api:field name="ID_Tarifgebiet"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:uniquekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_OrtspunktTG" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Eindeutige Datensatz-ID innerhalb der ID_Zeitraum
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Ortspunkt" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Referenz zum Ortspunkt, den der OrtspunktTG tarifgebietspezifisch ergänzt oder überschreibt.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Ortsbezeichnung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungKurz" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Kurzbezeichnung des Orts
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungDruck" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Bezeichnung des Orts für den Ausdruck
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Tarifgeberspez. Nr., bspw. für Aufdruck
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="OrtspunkteKA_Type">
+    <xs:annotation>
+      <xs:documentation>
+        KA-Attribute der Ortspunkte
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_OrtspunktKA"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:uniquekey name="Uix_OrtspunkteKA">
+          <api:field name="ID_Ortspunkt"/>
+          <api:field name="KA_OrtOrgID"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:uniquekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_OrtspunktKA" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Eindeutige Datensatz-ID innerhalb der ID_Zeitraum
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      
+      <xs:element name="ID_Ortspunkt" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Referenz zum Ortspunkt, den der OrtspunktKA um VDV KA Eigenschaften ergänzt.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      
+      <xs:element name="KA_OrtOrgID" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="KA_OrtTyp" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>KA Ortstyp</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_OrtNummer" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>KA Ortnummer</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Ortspunkte_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Haltestellen mit Zonen/Relationscode Zuordnung
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Ortspunkt"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:uniquekey name="Uix_Ortspunkte">
+          <api:field name="Ortsnummer"/>
+          <api:field name="ID_Ortspunkttyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:uniquekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Ortspunkt" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Eindeutige Datensatz-ID innerhalb der ID_Zeitraum
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Ortspunkttyp" type="husstDV:ID_Ortspunkttyp_Type" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bspw. Betriebshof</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Ortsnummer" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Bundeseinheitliche HST Nummer
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Relcode" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="IBISnr" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Bundesland" type="husstDV:ID_Bundesland_Type" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Gemeindekennziffer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Bezeichnung des Ortspunktes (z.B. für die
+            Anzeige)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungKurz" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Kurzbezeichnung des Ortspunktes (z.B. für
+            zusammengesetzte
+            Via-Information, wenn das Attribut leer ist, wird
+            Bezeichnung verwendet)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="BezeichnungDruck" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Bezeichnung des Ortspunktes für den Ausdruck
+            (wenn das
+            Attribut leer ist, wird Bezeichnung verwendet)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Tarifgeberspez. Nr., bspw. für Aufdruck
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Bediengebiet" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Bestimmt das Bediengebiet, das einzustellen ist, wenn dieser Ortspunkt als Standort ermittelt wird.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_OrtspunktReferenz" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Referenziert einen übergeordneten Ortspunkt
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="XKoordWgs84" type="husstDV:KoordWgs84_Type" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="YKoordWgs84" type="husstDV:KoordWgs84_Type" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Linien_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Linie"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+      <xs:documentation>Abbildung von Linien mit Zuordnung zum Fahrtverlauf. Dabei kann für die Hin- und Rückrichtung ein gesonderter Fahrtverlauf angegeben werden.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Linie" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Liniennummer</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Weg_Hin" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Linienhauptweg</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Weg_Rueck" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Linienhauptweg Rückrichtung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Konzessionaer" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Bediengebiet" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Wege_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Fahrtnummer, Kursnummer
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Weg"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Weg" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Eindeutige Nummer des Weges.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Wegpositionen_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Ortsposition innerhalb der Fahrt
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Wegposition"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:uniquekey name="Uix_Wegpositionen">
+          <api:field name="ID_Weg"/>
+          <api:field name="SortOrder"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:uniquekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Wegposition" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Weg" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="SortOrder" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Ortspunkt" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Bediengebiet" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Entfernung" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Entfernung vom vorhergehenden Ortspunkt in Metern
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="Fangbereich" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            optionaler Fangbereich der Wegposition in Metern
+            für eine
+            GPS Ortung - überschreibt eine entsprechende Angabe bei
+            der
+            Ortspunktdefinition
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_ProjektspezifischBitfeld_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Frei definierbare IDs für Def-Elemente auf Bitfeld Basis beginnen mit 1024
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:minInclusive value="1024"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_SortentypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST vordefinierten Sortentypen sind in verschiedene Bereiche geklustert:
+        1- 10 Bar
+        11- 20 Zeit
+        21- 30 Artikel
+        31- 40 Einzahlungen
+        41- 50 Leihgeld
+        991-999 Spezial
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Einzelkarte</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Mehrfahrten</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Zähler</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="11">
+        <xs:annotation>
+          <xs:documentation>Tageskarte</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="12">
+        <xs:annotation>
+          <xs:documentation>Wochenkarte</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="13">
+        <xs:annotation>
+          <xs:documentation>Monatskarte</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="14">
+        <xs:annotation>
+          <xs:documentation>Halbjahreskarte</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="15">
+        <xs:annotation>
+          <xs:documentation>Jahreskarte</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="21">
+        <xs:annotation>
+          <xs:documentation>Artikel</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="22">
+        <xs:annotation>
+          <xs:documentation>Gutschein (Verkauf)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="23">
+        <xs:annotation>
+          <xs:documentation>Gutschein (Annahme)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="24">
+        <xs:annotation>
+          <xs:documentation>Gutschein (Restwert)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="31">
+        <xs:annotation>
+          <xs:documentation>Verkäufer Einzahlung</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="32">
+        <xs:annotation>
+          <xs:documentation>Abo Einzahlung</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="33">
+        <xs:annotation>
+          <xs:documentation>EBE Einzahlung</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="39">
+        <xs:annotation>
+          <xs:documentation>Sonstige Einzahlung</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="41">
+        <xs:annotation>
+          <xs:documentation>Pfand (z.B. für Kundendatenträger)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="42">
+        <xs:annotation>
+          <xs:documentation>Kaution</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="991">
+        <xs:annotation>
+          <xs:documentation>Fehleinnahme</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="992">
+        <xs:annotation>
+          <xs:documentation>Bargutschrift (Überzahlung / Restgeldquittung etc.)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="999">
+        <xs:annotation>
+          <xs:documentation>Sonstige</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Sortentyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Sortentyp ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_SortentypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_TarifpunkttypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>Die HUSST definiert Tarifpunkttypen kleiner 1000</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Tarifhaltestelle (falls jede Hst ein eigener Tarifpunkt bildet)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Zone / Wabe / Ring (unmittelbar einer Tarifhaltestelle zugeordnet)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Überzone / Wabentyp (faßt Tarifpunkte vom Typ 2 oder 1 zusammen)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>Region (faßt Überzonen zu Regionen zusammen)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="5">
+        <xs:annotation>
+          <xs:documentation>Ortsteil (in seiner Funktion als Tarifpunkt)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="6">
+        <xs:annotation>
+          <xs:documentation>Ort (faßt Ortsteile zusammen)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Tarifpunkttyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Tarifpunkttyp ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_TarifpunkttypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_OrtspunkttypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>Die HUSST definiert Ortspunkttypen kleiner 1000</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Haltestelle</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Betriebshof</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Zone/Wabe/Ring</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="5">
+        <xs:annotation>
+          <xs:documentation>Gemeinde</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Ortspunkttyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Ortspunkttyp ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_OrtspunkttypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_OTPTypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert OTPTypen kleiner 1000
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>
+            Standort
+
+            Zu jedem Tarifrelevantenpunkt vom OTPTyp Standort muss es einen eindeutigen Ortspunkt geben. (Über ID_Ortspunkt verwiesen)
+            =&gt; Es darf kein Ortspunkt mit 2 oder mehr verwiesenden Tarifrelevantenpunkten vom OTPTyp Standort geben.
+
+            Über diesen Ortspunkt ist der Standort eines Vertriebsgerätes synchronisierbar. Z.B. über seine IBISnr oder ReferenzExtern
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Startpunkt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Zielpunkt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>Viapunkt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_OTPTyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_OTPTyp ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_OTPTypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_PreisquelleHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST reserviert ID_Preisquelle kleiner 1000, aktuell werden keine Standard-Preisquellen definiert.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:minExclusive value="0"/>
+      <xs:maxExclusive value="0"/>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Preisquelle_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Preisquelle ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_PreisquelleHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_PreisspaltentypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>Die HUSST definiert ID_Preisspaltentyp kleiner 1000</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Standard / Standardpreisspalte für den allgemeinen Verkauf</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Preisspaltentyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Preisspaltentyp ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_PreisspaltentypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_RelcodegruppentypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>Die HUSST definiert ID_Relcodegruppentyp kleiner 1000</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Magnet</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Startort</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Relcodegruppentyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Relcodegruppentyp ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_RelcodegruppentypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_SortengruppentypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Sortengruppentyp sind in verschiedene Bereicht geklustert:
+        1-10 Verkaufssortengruppe
+        11-20 Zusatzsortengruppen
+        21-30 Gruppenfahrschein
+        31-40 SortengruppenErmittlung-Gruppen
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>
+            Verkaufssortengruppe Relation
+            Mit der "Verkaufssortengruppe Relation"
+            werden alle Sorten zusammengefasst, die aufgrund von Serviceklasse, Rabattklasse und Fahrgasttyp
+            untereinander austauschbar sind und deren Preisstufe über eine Reisewegauswahl 
+            (i.d.R. Relation) ermittelt wird. 
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>
+            Verkaufssortengruppe Festpreis
+            Diese Sortengruppen werden beim Verkauf ohne Relationsauswahl angeboten.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>
+            Verkaufssortengruppe Kombi
+            Diese Sortengruppen fassen Sorten zusammen, die in Kombination angeboten werden können.
+            Die Auswahlsorte soll SortOrder 1 haben.
+            Beispiel:
+            Einfache Fahrt 2. Klasse + Hundeticket + Fahrrad
+            bzw.
+            Hin- und Rückfahrt 2. Klasse + Hundeticket Hin-/Rück + Fahrrad
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      
+      <xs:enumeration value="11">
+        <xs:annotation>
+          <xs:documentation>
+            Hauptsorten zu Zusatzsorten
+            Unter dem Sortengruppentyp werden Sorten zusammengefasst, die als Hauptsorte zu einem oder mehreren Zusatzsorten definiert sind.
+            In den Zusatzsorten wird im Attribut "ID_SortengruppeHauptsorten" auf die Sortengruppe von diesem Typ verwiesen.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="21">
+        <xs:annotation>
+          <xs:documentation>
+            Gruppenfahrschein
+            Ist für Gruppenfahrscheine, bei denen zusammen unterschiedlich Ausprägungen auf ein Ticket gedruckt werden.
+            Bsp.: Ein Fahrschein mit x Erwachsenen und y Kindern.
+            Es werden die Auswahlsorte und die Ausprägungen in eine Gruppe zusammengefasst.
+            Die Auswahlsorte soll Sortorder 1 haben.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="31">
+        <xs:annotation>
+          <xs:documentation>
+            SortengruppenErmittlung
+            Ist für Referenzen vom SortengruppenErmittlungen_Type. (s. SortengruppenErmittlungen_Type)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Sortengruppentyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Sortengruppentyp ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_SortengruppentypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefTarifpunkttyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Tarifpunkttyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Definiert die Art eines Tarifpunktes (Tarifhaltestelle, Zone/Wabe/Ring, Überzone/Wabentyp etc..) siehe ID_Tarifpunkttyp_Type bzw.
+        ID_TarifpunkttypHusst_Type
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifpunkttyp" type="husstDV:ID_Tarifpunkttyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefSortentyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Sortentyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>
+        Die vordefinierten Sortentypen stellen eine grobe Klassizifzierung der Sorte dar.
+        Anhand des Sortentyps kann das Vorgehen des Vertriebssystems gesteuert werden.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Sortentyp" type="husstDV:ID_Sortentyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefSortengruppentyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Sortengruppentyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Definiert den Verwendungszweck eines Typs von Sortengruppen. Siehe auch ID_Sortengruppentyp_Type bzw. ID_SortengruppentypHUSST_Type.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Sortengruppentyp" type="husstDV:ID_Sortengruppentyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Mwst_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Mwst"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+
+      </xs:appinfo>
+      <xs:documentation>Definition aller Mehrwertsteuersätze zur jeweiligen Referenzierung in Preisstufen, Sorten und Preisen</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Mwst" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Kennung des Mehrwertsteuersatzes
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="MwstSatz" type="husstDV:FLOAT1" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Prozentzahl des Mehrwertsteuersatzes
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Info zum MwSt.-Satz; bspw. ermäßigter Steuersatz
+            etc.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte
+            Mehrwertsteuerdatensätze über eine nicht numerische Referenz
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="KA_Mwst" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefPreisspaltentyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Preisspaltentyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>
+        Definiert den Verwendungszweck oder die Herkunft einer Preisspalte.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Preisspaltentyp" type="husstDV:ID_Preisspaltentyp_Type" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation/>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="Kennung" type="xs:string" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Zur eindeutigen Identifikation des Preisspaltentyps.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Zur Anzeige des Preispalten-Typs.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Zur externen Synchronisation des Preisspaltentyps.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefFahrgasttyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Fahrgasttyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Der Fahrgasttyp bezeichnet die tarifrele-vante Kategorie eines Fahrgastes z.B. Kind, Erwachsener, Rentner usw.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Fahrgasttyp" type="husstDV:ID_Fahrgasttyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung des Fahrgasttyps</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_FahrgasttypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Fahrgasttyp kleiner 1000
+        angelehnt an VDV-KA Kundentyp
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Erwachsener</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Kind</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Student</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="5">
+        <xs:annotation>
+          <xs:documentation>Behinderter</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="6">
+        <xs:annotation>
+          <xs:documentation>Sehbehinderter</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="7">
+        <xs:annotation>
+          <xs:documentation>Hörgeschädigter</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="8">
+        <xs:annotation>
+          <xs:documentation>Arbeitsloser/Sozialhilfeempfänger</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="9">
+        <xs:annotation>
+          <xs:documentation>Personal</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="10">
+        <xs:annotation>
+          <xs:documentation>Militärangehöriger</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="19">
+        <xs:annotation>
+          <xs:documentation>Schüler</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="20">
+        <xs:annotation>
+          <xs:documentation>Azubi</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="25">
+        <xs:annotation>
+          <xs:documentation>Senior</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="64">
+        <xs:annotation>
+          <xs:documentation>ermäßigt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      
+      <xs:enumeration value="65">
+        <xs:annotation>
+          <xs:documentation>Fahrrad</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      
+      <xs:enumeration value="66">
+        <xs:annotation>
+          <xs:documentation>Hund</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Fahrgasttyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Fahrgasttyp ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_FahrgasttypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefKomfortklasse_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Komfortklasse"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Definiert die Komfortklasse für deren Benutzung die Fahrscheinsorte berechtigt (z.B. 1 für 1. Klasse, 2 für 2. Klasse)</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Komfortklasse" type="husstDV:ID_Komfortklasse_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung der Komfortklasse.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_KomfortklasseHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Komfortklasse kleiner 1000
+        angelehnt an VDV-KA ServiceKlasse (reserviert: 0-255)
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>1. Klasse</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>2. Klasse</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>      
+      <xs:enumeration value="300">
+        <xs:annotation>
+          <xs:documentation>Übergang von der 2. zur 1. Klasse</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>      
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Komfortklasse_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Komfortklasse ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_KomfortklasseHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefRabattklasse_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Rabattklasse"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Definiert die Rabattklasse, z.B. "BahnCard50 1.Kl.", auf die in Sorten verweisen wird.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Rabattklasse" type="husstDV:ID_Rabattklasse_Type" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Eindeutige ID der Rabattklassse</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung der Rabattklasse.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_RabattklasseHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Rabattklasse kleiner 1000
+        angelehnt an VDV-KA RabattParameter
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>Keine Ermäßigung</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>
+            prozentuale Ermäßigung
+            Level-1
+            (z.B. Bahncard 25)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>
+            prozentuale Ermäßigung18
+            Level-2
+            (z.B. Bahncard 50)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>
+            prozentuale Ermäßigung
+            Level-3
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>
+            prozentuale Ermäßigung
+            Level-4
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="5">
+        <xs:annotation>
+          <xs:documentation>
+            prozentuale Ermäßigung
+            Level-5
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="6">
+        <xs:annotation>
+          <xs:documentation>
+            Ermäßigung auf Basis
+            gefahrener Kilometer
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="46">
+        <xs:annotation>
+          <xs:documentation>
+            Ermäßigung des
+            Ticketkaufs mit
+            KA-Bezahlberechtigung um 25%
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Rabattklasse_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Rabattklasse ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_RabattklasseHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefPreisfindung_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Preisfindung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Definiert die Art der Preisfindung für eine Sorte. Z.B. Festpreis, Relationbezogen, etc.
+        Siehe auch ID_Preisfindung_Type bzw. ID_PreisfindungHUSST_Type.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Preisfindung" type="husstDV:ID_Preisfindung_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung des Preisfindungs</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_PreisfindungHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Preisfindung kleiner 1000
+        Bit 0=Festpreis
+        Bit 1=Relationsbezogen (nicht mit Bit 0 kombinierbar)
+        Bit 2=Preisstufenupgrade (nur mit Bit 1 kombinierbar)
+        Bit 8=Freie Preiseingabe (mit allen kombinierbar)
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Festpreis</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Relationsbezogen</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="6">
+        <xs:annotation>
+          <xs:documentation>
+            Relationsbezogen mit Preisstufenupgrade
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="257">
+        <xs:annotation>
+          <xs:documentation>
+            Festpreis mit freier Preiseingabe
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="258">
+        <xs:annotation>
+          <xs:documentation>
+            Relationsbezogen mit freier Preiseingabe
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="262">
+        <xs:annotation>
+          <xs:documentation>
+            Relationsbezogen mit Preisstufenupgrade und
+            freier Preiseingabe
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Preisfindung_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Preisfindung ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_PreisfindungHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefSortenausgaberegelung_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Sortenausgaberegelung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>
+        Die Sortenausgaberegelung bestimmt in welcher Art diese Sorte ausgegeben werden darf.
+        Bsp. Papierfahrschein oder eTicket.
+        Die Werte werden als Bitmaske behandelt, sodass an einer Sorte mehrere Ausgabemethoden erlaubt sein können.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Sortenausgaberegelung" type="husstDV:ID_Sortenausgaberegelung_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung des Sortenausgaberegelungs</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_SortenausgaberegelungHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Sortenausgaberegelung kleiner 1024
+        Die Werte ergeben sich aus allen 32 möglichen Bitkombinationen der ersten 5 Bit.
+
+        Bit 0=Papierfahrschein
+        Bit 1=EFS (z.B. Chipkarte)
+        Bit 2=Handy Ticket
+        Bit 3=Papierfahrschein mit Barcode
+        Bit 4=EFS und Papierfahrschein [mit Barcode]
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Papierfahrschein</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>EFS (z.B. Chipkarte)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>Handy Ticket</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="8">
+        <xs:annotation>
+          <xs:documentation>Papierfahrschein mit Barcode</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="16">
+        <xs:annotation>
+          <xs:documentation>
+            EFS und Papierfahrschein [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / EFS (z.B. Chipkarte)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="5">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / Handy Ticket
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="9">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / Papierfahrschein mit Barcode
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="17">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / EFS und Papierfahrschein [mit
+            Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="6">
+        <xs:annotation>
+          <xs:documentation>
+            EFS (z.B. Chipkarte) / Handy Ticket
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="10">
+        <xs:annotation>
+          <xs:documentation>
+            EFS (z.B. Chipkarte) / Papierfahrschein mit
+            Barcode
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="18">
+        <xs:annotation>
+          <xs:documentation>
+            EFS (z.B. Chipkarte) / EFS und Papierfahrschein
+            [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="12">
+        <xs:annotation>
+          <xs:documentation>
+            Handy Ticket / Papierfahrschein mit Barcode
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="20">
+        <xs:annotation>
+          <xs:documentation>
+            Handy Ticket / EFS und Papierfahrschein [mit
+            Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="24">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein mit Barcode / EFS und
+            Papierfahrschein [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="7">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / EFS (z.B. Chipkarte) / Handy
+            Ticket
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="11">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / EFS (z.B. Chipkarte) /
+            Papierfahrschein mit Barcode
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="19">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / EFS (z.B. Chipkarte) / EFS und
+            Papierfahrschein [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="13">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / Handy Ticket /
+            Papierfahrschein mit Barcode
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="21">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / Handy Ticket / EFS und
+            Papierfahrschein [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="25">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / Papierfahrschein mit Barcode /
+            EFS und Papierfahrschein [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="14">
+        <xs:annotation>
+          <xs:documentation>
+            EFS (z.B. Chipkarte) / Handy Ticket /
+            Papierfahrschein mit Barcode
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="22">
+        <xs:annotation>
+          <xs:documentation>
+            EFS (z.B. Chipkarte) / Handy Ticket / EFS und
+            Papierfahrschein [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="26">
+        <xs:annotation>
+          <xs:documentation>
+            EFS (z.B. Chipkarte) / Papierfahrschein mit
+            Barcode / EFS und Papierfahrschein [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="28">
+        <xs:annotation>
+          <xs:documentation>
+            Handy Ticket / Papierfahrschein mit Barcode / EFS
+            und Papierfahrschein [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="15">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / EFS (z.B. Chipkarte) / Handy
+            Ticket / Papierfahrschein mit Barcode
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="23">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / EFS (z.B. Chipkarte) / Handy
+            Ticket / EFS und Papierfahrschein [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="27">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / EFS (z.B. Chipkarte) /
+            Papierfahrschein mit Barcode /
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="30">
+        <xs:annotation>
+          <xs:documentation>
+            EFS (z.B. Chipkarte) / Handy Ticket /
+            Papierfahrschein mit Barcode / EFS und Papierfahrschein [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="29">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / Handy Ticket /
+            Papierfahrschein mit Barcode / EFS und Papierfahrschein [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="31">
+        <xs:annotation>
+          <xs:documentation>
+            Papierfahrschein / EFS (z.B. Chipkarte) / Handy
+            Ticket / Papierfahrschein mit Barcode / EFS und Papierfahrschein
+            [mit Barcode]
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Sortenausgaberegelung_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Sortenausgaberegelung ist entweder eine von HUSST vordefinierter Zahl kleiner 1024 oder eine im Projekt vereinbarte Zahl größer gleich 1024.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_SortenausgaberegelungHUSST_Type husstDV:ID_ProjektspezifischBitfeld_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefSortendruckregelung_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Sortendruckregelung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Die Sortendruckregelung definiert die Art, in der ein Fahrschein gedruckt wird.
+        Defaultmäßig wird das am Preise / an der Sorte definierte Layout verwendet (Vordefinierter Wert 1).
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Sortendruckregelung" type="husstDV:ID_Sortendruckregelung_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung des Sortendruckregelungs</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_SortendruckregelungHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Sortendruckregelung kleiner 1000
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Druck über Layout</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Vorrangiger Druck über ein zum Verkaufszeitpunkt zugeordnetes Hauptprodukt, sonst über Layout.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>
+            Druck eines 2. Fahrscheins mit einer Druckinformation
+            "2. Druck" die im Layout ausgewertet werden kann.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Sortendruckregelung_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Sortendruckregelung ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_SortendruckregelungHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefReisetyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Reisetyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Beschreibt den Typ der Reise (normale Fahrt, HinUndRück, Rundreise, ...), auf den in Sorten verwiesen wird.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Reisetyp" type="husstDV:ID_Reisetyp_Type" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Eindeutige ID des Reisetyps</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung des Reisetyps</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_ReisetypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Reisetyp kleiner 1000
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Standard (passend zum Sortentyp)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Hin- und Rückfahrt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Rundreise</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Reisetyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Reisetyp ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_ReisetypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefNachbarhaltestellenbeziehung_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Art einer Nachbarhaltestellenbeziehung.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Nachbarhaltestellenbeziehung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Nachbarhaltestellenbeziehung" type="husstDV:ID_Nachbarhaltestellenbeziehung_Type" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Art der Nachbarbeziehung.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Bezeichnung der Art der Nachbarbeziehung.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_NachbarhaltestellenbeziehungHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Nachbarhaltestellenbeziehung kleiner 1000
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>
+            nicht spezifiziert/unbestimmt
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>
+            Kurzstrecke
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Nachbarhaltestellenbeziehung_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Nachbarhaltestellenbeziehung ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_NachbarhaltestellenbeziehungHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefVertriebswege_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Vertriebswege"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+      <xs:documentation>
+        Die Vertriebswege kommen bei verschiedenen Typen als Attribut vor. In erster Linie werden sie
+        dazu verwendet, die Datenmenge für verschiedene Verkaufsgeräte zu reduzieren, indem
+        Elemente, die der entsprechenden Vertriebstechnik nicht zugeordnet sind, auch nicht mit den
+        Herstellerunabhängige Standardschnittstelle
+        "Datenaustausch in ÖPV-Vertriebssystemen" 2010-2012 Seite 37 von 178
+        Daten versorgt werden. Teilweise haben die Vertriebswege aber auch steuernden Charakter auf
+        den Verkaufsgeräten. Z.B. kann mit den Vertriebswegen festgelegt sein, dass eine bestimmte
+        Sorte als elektronischer Fahrschein verkauft werden darf, oder eben nicht.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Vertriebswege" type="husstDV:ID_Vertriebswege_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung der Vertriebswege.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_VertriebswegeHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Vertriebswege kleiner 1024
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Vertriebswege_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Vertriebswege ist entweder eine von HUSST vordefinierter Zahl kleiner 1024 oder eine im Projekt vereinbarte Zahl größer gleich 1024.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_VertriebswegeHUSST_Type husstDV:ID_ProjektspezifischBitfeld_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="Vorverkauf_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Definiert den Zeitraum, in dem der Fahrschein im Voraus verkaufbar ist.
+        Die Syntax der Formel wird in einer eigenen HUSST-Definition konkretisiert.
+        todo: Olaf definiert, Horst formuliert reguläre Ausdrücke
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="Umschalttag_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Definiert den Zeitraum, in dem der Fahrschein im Voraus verkaufbar ist.
+        Die Syntax der Formel wird in einer eigenen HUSST-Definition konkretisiert.
+        todo: Olaf definiert, Horst formuliert reguläre Ausdrücke
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="GueltigkeitszeitRegeln_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Definiert eine zeitliche Gültigkeit. Darin enthalten sein kann auch die Vorverkaufbarkeit
+        (Regel zum möglichen Gültigkeitsbeginn) und die Umschaltung auf einen neuen Default-Gültigkeitsbeginn.
+        Der Datentyp wird noch weiter ausgebaut und in einer eigenen HUSST-Definition konkretisiert.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_GueltigkeitszeitRegel"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_GueltigkeitszeitRegel" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="GueltigkeitszeitRegelNr" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Param" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefZahlungsarten_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Zahlungsarten"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Zahlungsarten definieren ein Verfahren, mit dem eine Sorte bezahlt werden kann.
+        Siehe auch ID_Zahlungsarten_Type bzw. ID_ZahlungsartenHUSST_Type.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Zahlungsarten" type="husstDV:ID_Zahlungsarten_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung der Zahlungsarten.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_Zahlungsarten_Type">
+    <xs:annotation>
+      <xs:documentation>Die ID_Zahlungsarten ist entweder eine von HUSST vordefinierter Zahl kleiner 1024 oder eine im Projekt vereinbarte Zahl größer gleich 1024.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_ZahlungsartenHUSST_Type husstDV:ID_ProjektspezifischBitfeld_Type"/>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_ZahlungsartenHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Zahlungsart kleiner 1024
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>
+            Barzahlung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>
+            Kartenzahlung
+            (Schließt alle Arten der Kartenzahlung ein, die das System unterstützt)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>
+            KA-Zahlung
+            (POB, PEB und WEB)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="8">
+        <xs:annotation>
+          <xs:documentation>
+            Rechnung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <!--Ab hier zusätzliche Werte, damit das Enum als Bitfeld verwendet werden kann, ohne dass eine Validierung fehlschlägt.-->
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>
+            Keine
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>
+            Barzahlung / Kartenzahlung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="5">
+        <xs:annotation>
+          <xs:documentation>
+            Barzahlung / KA-Zahlung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="6">
+        <xs:annotation>
+          <xs:documentation>
+            Kartenzahlung / KA-Zahlung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="7">
+        <xs:annotation>
+          <xs:documentation>
+            Barzahlung / Kartenzahlung / KA-Zahlung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="9">
+        <xs:annotation>
+          <xs:documentation>
+            Barzahlung / Rechnung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="10">
+        <xs:annotation>
+          <xs:documentation>
+            Kartenzahlung / Rechnung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="11">
+        <xs:annotation>
+          <xs:documentation>
+            Barzahlung / Kartenzahlung / Rechnung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="12">
+        <xs:annotation>
+          <xs:documentation>
+            KA-Zahlung / Rechnung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="13">
+        <xs:annotation>
+          <xs:documentation>
+            Barzahlung / KA-Zahlung / Rechnung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="14">
+        <xs:annotation>
+          <xs:documentation>
+            Kartenzahlung / KA-Zahlung / Rechnung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="15">
+        <xs:annotation>
+          <xs:documentation>
+            Barzahlung / Kartenzahlung / KA-Zahlung / Rechnung
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:complexType name="Tarifarten_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Gruppierungs- (Sorten via SortenTarifarten) und
+        Differenzierungsattribut (Teilrelationen,
+        Preisstufendirektwahlen).
+        Damit lassen sich z.B. eigene
+        Relationen für ganze Gruppen von
+        Fahrscheinensorten vom
+        allgemeinen Fall abtrennen
+        (Bartarif/Zeittarif).
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Tarifart"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifart" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Zum Beispiel: 0=Allgemein, 1=Bartarif, 2=Zeittarif
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="ReferenzExtern" type="xs:string" maxOccurs="1" minOccurs="0"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefRelationscodegruppentyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        bspw. als Magneten für Citytarif
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Relcodegruppentyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relcodegruppentyp" type="husstDV:ID_Relcodegruppentyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefOrtspunkttyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Ortspunkttyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+      <xs:documentation>
+        Definiert die Bedeutung eines Ortspunktes.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Ortspunkttyp" type="husstDV:ID_Ortspunkttyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Tarifrelevantepunkte_Type">
+    <xs:annotation>
+      <xs:documentation>
+        OTP - Orte und tarifrelevante Punkte. Unabhhänig
+        von konkreten
+        Haltestellen bieten tarifrelevante Punkte die
+        Möglichkeit, dem
+        Bediener Reiseziele anzubieten, zu denen einen
+        Verkauf erfolgen
+        soll. Jedem OTP ist genau ein Relationscode
+        zugeordnet, über den
+        Relationen gesucht werden.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Tarifrelevanterpunkt"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifrelevanterpunkt" type="husstDV:INT4" maxOccurs="1" minOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Eindeutiger DS-Index innerhalb der ID_Zeitraum
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_OTPTyp" type="husstDV:ID_OTPTyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Bediengebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="SortOrder" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relcode" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Bundesland" type="husstDV:ID_Bundesland_Type" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Ortspunkt" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Sortengruppe" type="husstDV:INT4" maxOccurs="1" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>
+            Verweist auf eine Sortengruppe, die mit dieser
+            Zielauswahl direkt verkauft wird (Festpreis, keine Relation)
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Standortwahl_ID_Bediengebiet" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_TarifrelevanterpunktReferenz" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Über ID_TarifrelevanterpunktReferenz kann eine baumartige
+            Auswahlstruktur definiert werden. Blätter und Knoten
+            referenzieren über ID_TarifrelevanterpunktReferenz
+            einen Elternknoten im selben Zeitraum.
+            Die Bildung von Referenzbäumen ist
+            optional. SortOrder definiert
+            die Sortierung aller Kindknoten eines Elternknotens.
+            Innerhalb der gleichen SortOrder
+            werden die Knoten alphabetisch sortiert.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Bediengebiete_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Bediengebiete erlauben die Defintion von Sichten
+        auf Auswahlelemente (Tarifrelevante Punkte, Haltestellen, etc.).
+        Damit ist die Möglichkeit zur Filterung von Start/Zielauswahlen
+        in verschiedenen Umfeldern möglich.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Bediengebiet"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Bediengebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefOTPTyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_OTPTyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+
+      </xs:appinfo>
+      <xs:documentation>Definiert den Verwendungszweck eines Typs von Tarifrelevantenpunkten
+        (OTP steht für Orte und Tarifrelevante Punkte).
+        Siehe auch ID_OTPTyp_Type bzw. ID_OTPTypHUSST_Type
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_OTPTyp" type="husstDV:ID_OTPTyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Sortengruppen_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Sortengruppe"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+
+        <api:schema name="Tarif"/>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+      <xs:documentation>
+        Sortengruppen können Sorten für unterschiedliche Anwendungsfälle gruppieren.
+        Der Anwendungsfall wird über den Sortengruppentyp unterschieden werden.
+        Seine Bedeutung ist projektspezifisch zu konkretisiern.
+        Den zugeordneten Sorten können auch Preisstufen zugeordnet sein.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Sortengruppe" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Sortengruppentyp" type="husstDV:ID_Sortengruppentyp_Type" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Bediengebiet" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="SortOrder" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Info</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Externer Schlüssel für die Sortengruppe.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefPreisquelle_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Preisquelle"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+      <xs:documentation>Definiert eine Quellenangabe die einer Teilrelation zugeordnet werden kann. Quellenangaben dienen im wesentlichen der späteren Ausgabezuscheidung.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Preisquelle" type="husstDV:ID_Preisquelle_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Bezeichnung der Preisquelle z.B.
+            NE-Blatt-Nummer
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefRelationenberechnungsregelung_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Relationenberechnungsregelung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+      <xs:documentation>
+        Die Berechnungsregelung bestimmt, wie die Teilrelationen zu einer Relation zu verarbeiten sind.
+        Diese Regelung kann dabei Auswirkungen auf den Preis haben.
+        Die Husst definierten Werte sind genau beschrieben, eigene Werte müssen gut abgestimmt sein.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relationenberechnungsregelung" type="husstDV:ID_Relationenberechnungsregelung_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefRelationendruckregelung_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Relationendruckregelung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+      <xs:documentation>
+        Die Druckregelung bestimmt, wie die Werte der Teilrelationen zu drucken sind.
+        Die Husst definierten Werte sind genau beschrieben, eigene Werte müssen gut abgestimmt sein.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relationendruckregelung" type="husstDV:ID_Relationendruckregelung_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefErmittlungseinheit_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Ermittlungseinheit"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Ermittlungseinheit" type="husstDV:ID_Ermittlungseinheit_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung der Ermittlungseinheit</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_ErmittlungseinheitHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Ermittlungseinheit kleiner 1000
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>
+            Minuten
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>
+            Kilometer
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Ermittlungseinheit_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Ermittlungseinheit ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_ErmittlungseinheitHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefStreckenart_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Streckenart"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckenart" type="husstDV:ID_Streckenart_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung der Streckenart</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_StreckenartHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Streckenart kleiner 1000.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>
+            keine Sonderverkaufslogik
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>
+            Strecke nur kombiniert mit ID_Streckenart=1 verkaufbar
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>
+            nur als Einzelstrecke verkaufbar
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Streckenart_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Streckenart ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_StreckenartHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="DefStreckencodetyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Streckencodetyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckencodetyp" type="husstDV:ID_Streckencodetyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Bezeichnung der Streckencodetyp</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:simpleType name="ID_StreckencodetypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Streckencodetyp kleiner 1000.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>
+            AST Anstoßbahnhof
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>
+            NAST Nichtanstoßbahnhof
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>
+            NE-Haltepunkt
+          </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+  
+  <xs:simpleType name="ID_Streckencodetyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Streckencodetyp ist entweder eine von HUSST vordefinierter Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_StreckencodetypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+  
+  <xs:complexType name="Strecke_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Strecke eines Streckentarifs.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Strecke"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Strecke" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_StreckencodeStart" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_StreckencodeZiel" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Entfernung" type="husstDV:INT4" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Entfernungswert der Strecke zur Tarifberechnung.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="SortOrder" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Via" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Nummer der Viatexte für diese Strecke. Verweis auf Vias.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Streckenart" type="husstDV:ID_Streckenart_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Definiert Verkaufbarkeitseinschränkungen dieser Strecke.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schlüssel des Tarifgebers für diese Strecke
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Streckencode_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Analog zum Relationscode kombiniert ein ID_Streckencode zu einem oder mehreren ID_Tarifpunkten.
+        Anders als Relationscodes sind Streckencodes aber Tarifgebiethomogen.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Streckencode"/>
+          <api:field name="ID_Tarifpunkt"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckencode" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifpunkt" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckencodetyp" type="husstDV:ID_Streckencodetyp_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Typ dieses Streckencodes (dieses Haltepunktes).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schlüssel des Tarifgebers für diesen Streckencode.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="OrtspunktStreckencode_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Ordnet einen Ortspunkt einem Streckencode in einem Tarifgebiet zu.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Ortspunkt"/>
+          <api:field name="ID_Tarifgebiet"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Ortspunkt" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckencode" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckencodetyp" type="husstDV:ID_Streckencodetyp_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Typ dieses Streckencodes (dieses Haltepunktes).
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schlüssel des Tarifgebers für diese Ortspunkt-Streckencode Zuordnung.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Streckenzuordnung_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Ordnet eine Strecke einem oder mehreren Teilrelationen zu.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Strecke"/>
+          <api:field name="ID_Teilrelation"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Strecke" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Teilrelation" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schlüssel des Tarifgebers für diese Strecke-Teilrelations Zuordnung.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Gleichstellungstyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die Art der Gleichstellung.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Gleichstellungstyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Gleichstellungstyp" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schlüssel des Tarifgebers für diesen Gleichstellungstyp.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="GleichstellungTarifart_Type">
+    <xs:annotation>
+      <xs:documentation>
+        einen Gelichstellungstyp einer Tarifart zu.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Gleichstellungstyp"/>
+          <api:field name="ID_Tarifart"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Gleichstellungstyp" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifart" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schlüssel des Tarifgebers für diese Gleichstellungstyp-Tarifart Zuordnung.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="Gleichstellung_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Tarifliche Gleichstellung eines Starts oder eines Ziels einer Strecke ab einer definierten Gesamtentfernung.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Gleichstellung"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Gleichstellung" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Tarifgebiet" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckencode" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_StreckencodeGleichstellung" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Gleichstellungstyp" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="EntfernungAb" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schlüssel des Tarifgebers für diese Gleichstellung.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="StreckencodeVerlauf_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Ein richtungsgebundener Verlauf von Streckencodes, welcher eine Verbindung über verschiedene Streckencodes als Vias darstellt.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Streckencode"/>
+          <api:field name="ID_StreckencodeVerlauf"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_StreckencodeVerlauf" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckencode" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="IstViapunkt" type="xs:boolean" maxOccurs="1" minOccurs="1">
+      <xs:annotation>
+          <xs:documentation>
+            Gibt an, ob der Streckencode eine Relevanz bei der Streckensuche hat.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="SortOrder" type="husstDV:INT4" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Reihenfolge der Streckencodes in der sie durchfahren werden.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <!--Ende Tabellen -->
+  
+  <!--Allgemein -->
+  
+  <xs:element name="Tarifgebiete" type="husstDV:Tarifgebiete_Type"/>
+  
+  <xs:element name="Tarifpunkte" type="husstDV:Tarifpunkte_Type"/>
+  
+  <xs:element name="TarifpunktmengeElemente" type="husstDV:TarifpunktmengeElemente_Type"/>
+  
+  <xs:element name="Tarifpunktmengen" type="husstDV:Tarifpunktmengen_Type"/>
+  
+  <!--Relationen -->
+  
+  <xs:element name="RaeumlicheGueltigkeit" type="husstDV:RaeumlicheGueltigkeit_Type"/>
+  
+  <xs:element name="Relationscodes" type="husstDV:Relationscodes_Type"/>
+  
+  <xs:element name="Relationscodegruppen" type="husstDV:Relationscodegruppen_Type"/>
+  
+  <xs:element name="Relationen" type="husstDV:Relationen_Type"/>
+  
+  <xs:element name="Vias" type="husstDV:Vias_Type"/>
+  
+  <xs:element name="Teilrelationen" type="husstDV:Teilrelationen_Type"/>
+  
+  <xs:element name="Nachbarhaltestellen" type="husstDV:Nachbarhaltestellen_Type"/>
+  
+  <xs:element name="DefZahlgrenzentyp" type="husstDV:DefZahlgrenzentyp_Type"/>
+  
+  <xs:element name="Preisstufendirektwahl" type="husstDV:Preisstufendirektwahl_Type"/>
+  
+  <!--Produkte -->
+  
+  <xs:element name="Preisspalten" type="husstDV:Preisspalten_Type"/>
+  
+  <xs:element name="Preisstufen" type="husstDV:Preisstufen_Type"/>
+  
+  <xs:element name="SortenTarifarten" type="husstDV:SortenTarifarten_Type"/>
+  
+  <xs:element name="Sorten" type="husstDV:Sorten_Type"/>
+  
+  <xs:element name="Zusatzsorten" type="husstDV:Zusatzsorten_Type"/>
+  
+  <xs:element name="Preise" type="husstDV:Preise_Type"/>
+  
+  <xs:element name="GueltigkeitszeitRegeln" type="husstDV:GueltigkeitszeitRegeln_Type"/>
+  
+  <xs:element name="PreisstufenErmittlungen" type="husstDV:PreisstufenErmittlungen_Type"/>
+  
+  <xs:element name="SortengruppenErmittlungen" type="husstDV:SortengruppenErmittlungen_Type"/>
+  
+  <!--Netz -->
+  
+  <xs:element name="OrtspunkteTG" type="husstDV:OrtspunkteTG_Type"/>
+  
+  <xs:element name="OrtspunkteKA" type="husstDV:OrtspunkteKA_Type"/>
+  
+  <xs:element name="Ortspunkte" type="husstDV:Ortspunkte_Type"/>
+  
+  <xs:element name="Tarifrelevantepunkte" type="husstDV:Tarifrelevantepunkte_Type"/>
+  
+  <xs:element name="Bediengebiete" type="husstDV:Bediengebiete_Type"/>
+  
+  <xs:element name="Linien" type="husstDV:Linien_Type"/>
+  
+  <xs:element name="Wege" type="husstDV:Wege_Type"/>
+  
+  <xs:element name="Wegpositionen" type="husstDV:Wegpositionen_Type"/>
+  
+  <!--Hilfs -->
+  
+  <xs:element name="DefTarifpunkttypen" type="husstDV:DefTarifpunkttyp_Type"/>
+  
+  <xs:element name="DefSortentypen" type="husstDV:DefSortentyp_Type"/>
+  
+  <xs:element name="Mwst" type="husstDV:Mwst_Type"/>
+  
+  <xs:element name="DefPreisspaltentypen" type="husstDV:DefPreisspaltentyp_Type"/>
+  
+  <xs:element name="Tarifarten" type="husstDV:Tarifarten_Type"/>
+  
+  <xs:element name="DefPreisquellen" type="husstDV:DefPreisquelle_Type"/>
+  
+  <xs:element name="DefRelationenberechnungsregelungen" type="husstDV:DefRelationenberechnungsregelung_Type"/>
+  
+  <xs:element name="DefRelationendruckregelungen" type="husstDV:DefRelationendruckregelung_Type"/>
+  
+  <xs:element name="DefRelationscodegruppentypen" type="husstDV:DefRelationscodegruppentyp_Type"/>
+  
+  <xs:element name="DefOrtspunkttypen" type="husstDV:DefOrtspunkttyp_Type"/>
+  
+  <xs:element name="DefOTPTypen" type="husstDV:DefOTPTyp_Type"/>
+  
+  <xs:element name="DefSortengruppentypen" type="husstDV:DefSortengruppentyp_Type"/>
+  
+  <xs:element name="Sortengruppen" type="husstDV:Sortengruppen_Type"/>
+  
+  <xs:element name="SortengruppenElemente" type="husstDV:SortengruppenElemente_Type"/>
+  
+  <xs:element name="DefFahrgasttypen" type="husstDV:DefFahrgasttyp_Type"/>
+  
+  <xs:element name="DefKomfortklassen" type="husstDV:DefKomfortklasse_Type"/>
+  
+  <xs:element name="DefNachbarhaltestellenbeziehungen" type="husstDV:DefNachbarhaltestellenbeziehung_Type"/>
+  
+  <xs:element name="DefPreisfindungen" type="husstDV:DefPreisfindung_Type"/>
+  
+  <xs:element name="DefRabattklassen" type="husstDV:DefRabattklasse_Type"/>
+  
+  <xs:element name="DefReisetypen" type="husstDV:DefReisetyp_Type"/>
+  
+  <xs:element name="DefSortenausgaberegelungen" type="husstDV:DefSortenausgaberegelung_Type"/>
+  
+  <xs:element name="DefSortendruckregelungen" type="husstDV:DefSortendruckregelung_Type"/>
+  
+  <xs:element name="DefVertriebswege" type="husstDV:DefVertriebswege_Type"/>
+  
+  <xs:element name="DefZahlungsarten" type="husstDV:DefZahlungsarten_Type"/>
+  
+  <xs:element name="DefErmittlungseinheit" type="husstDV:DefErmittlungseinheit_Type"/>
+  
+  <xs:element name="Relationszuordnungen" type="husstDV:Relationszuordnungen_Type"/>
+  
+  <xs:element name="DefStreckenart" type="husstDV:DefStreckenart_Type"/>
+  
+  <xs:element name="DefStreckencodetyp" type="husstDV:DefStreckencodetyp_Type"/>
+  
+  <xs:element name="Strecke" type="husstDV:Strecke_Type"/>
+  
+  <xs:element name="Streckencode" type="husstDV:Streckencode_Type"/>
+  
+  <xs:element name="OrtspunktStreckencode" type="husstDV:OrtspunktStreckencode_Type"/>
+  
+  <xs:element name="Streckenzuordnung" type="husstDV:Streckenzuordnung_Type"/>
+  
+  <xs:element name="Gleichstellungstyp" type="husstDV:Gleichstellungstyp_Type"/>
+  
+  <xs:element name="GleichstellungTarifart" type="husstDV:GleichstellungTarifart_Type"/>
+  
+  <xs:element name="Gleichstellung" type="husstDV:Gleichstellung_Type"/>
+  
+  <!--Wurzel -->
+  
+  <xs:element name="OePVTarifDB" type="husstDV:OePVTarifDB_Type"/>
+  
+  <xs:complexType name="OePVTarifDB_Type">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element ref="husstDV:DefFahrgasttypen"/>
+      <xs:element ref="husstDV:DefKomfortklassen"/>
+      <xs:element ref="husstDV:DefNachbarhaltestellenbeziehungen"/>
+      <xs:element ref="husstDV:DefPreisfindungen"/>
+      <xs:element ref="husstDV:DefRabattklassen"/>
+      <xs:element ref="husstDV:DefReisetypen"/>
+      <xs:element ref="husstDV:DefSortenausgaberegelungen"/>
+      <xs:element ref="husstDV:DefSortendruckregelungen"/>
+      <xs:element ref="husstDV:DefVertriebswege"/>
+      <xs:element ref="husstDV:DefZahlungsarten"/>
+      <xs:element ref="husstDV:Relationszuordnungen"/>
+      <xs:element ref="husstDV:DefStreckenart"/>
+      <xs:element ref="husstDV:DefStreckencodetyp"/>
+      <xs:element ref="husstDV:Bearbeitung"/>
+      <xs:element ref="husstDV:Bediengebiete"/>
+      <xs:element ref="husstDV:DefErmittlungseinheit"/>
+      <xs:element ref="husstDV:DefBundeslaender"/>
+      <xs:element ref="husstDV:DefOTPTypen"/>
+      <xs:element ref="husstDV:DefOrtspunkttypen"/>
+      <xs:element ref="husstDV:DefPreisquellen"/>
+      <xs:element ref="husstDV:DefPreisspaltentypen"/>
+      <xs:element ref="husstDV:DefRelationenberechnungsregelungen"/>
+      <xs:element ref="husstDV:DefRelationendruckregelungen"/>
+      <xs:element ref="husstDV:DefRelationscodegruppentypen"/>
+      <xs:element ref="husstDV:DefSortengruppentypen"/>
+      <xs:element ref="husstDV:DefSortentypen"/>
+      <xs:element ref="husstDV:DefTarifpunkttypen"/>
+      <xs:element ref="husstDV:DefWaehrungen"/>
+      <xs:element ref="husstDV:DefZahlgrenzentyp"/>
+      <xs:element ref="husstDV:Feiertage"/>
+      <xs:element ref="husstDV:Gleichstellung"/>
+      <xs:element ref="husstDV:GleichstellungTarifart"/>
+      <xs:element ref="husstDV:Gleichstellungstyp"/>
+      <xs:element ref="husstDV:GueltigkeitszeitRegeln"/>
+      <xs:element ref="husstDV:Interpretationen"/>
+      <xs:element ref="husstDV:Kalender"/>
+      <xs:element ref="husstDV:Linien"/>
+      <xs:element ref="husstDV:Mwst"/>
+      <xs:element ref="husstDV:Nachbarhaltestellen"/>
+      <xs:element ref="husstDV:OrtspunktStreckencode"/>
+      <xs:element ref="husstDV:Ortspunkte"/>
+      <xs:element ref="husstDV:OrtspunkteKA"/>
+      <xs:element ref="husstDV:OrtspunkteTG"/>
+      <xs:element ref="husstDV:Preise"/>
+      <xs:element ref="husstDV:Preisspalten"/>
+      <xs:element ref="husstDV:Preisstufen"/>
+      <xs:element ref="husstDV:PreisstufenErmittlungen"/>
+      <xs:element ref="husstDV:Preisstufendirektwahl"/>
+      <xs:element ref="husstDV:RaeumlicheGueltigkeit"/>
+      <xs:element ref="husstDV:Relationen"/>
+      <xs:element ref="husstDV:Relationscodegruppen"/>
+      <xs:element ref="husstDV:Relationscodes"/>
+      <xs:element ref="husstDV:Sorten"/>
+      <xs:element ref="husstDV:SortenTarifarten"/>
+      <xs:element ref="husstDV:Sortengruppen"/>
+      <xs:element ref="husstDV:SortengruppenElemente"/>
+      <xs:element ref="husstDV:SortengruppenErmittlungen"/>
+      <xs:element ref="husstDV:Strecke"/>
+      <xs:element ref="husstDV:Streckencode"/>
+      <xs:element ref="husstDV:Streckenzuordnung"/>
+      <xs:element ref="husstDV:TagesartMerkmalElemente"/>
+      <xs:element ref="husstDV:Tagesarten"/>
+      <xs:element ref="husstDV:TagesmerkmalElemente"/>
+      <xs:element ref="husstDV:Tagesmerkmale"/>
+      <xs:element ref="husstDV:Tarifarten"/>
+      <xs:element ref="husstDV:Tarifgebiete"/>
+      <xs:element ref="husstDV:Tarifpunkte"/>
+      <xs:element ref="husstDV:TarifpunktmengeElemente"/>
+      <xs:element ref="husstDV:Tarifpunktmengen"/>
+      <xs:element ref="husstDV:Tarifrelevantepunkte"/>
+      <xs:element ref="husstDV:Teilrelationen"/>
+      <xs:element ref="husstDV:Unternehmen"/>
+      <xs:element ref="husstDV:Updateinfo"/>
+      <xs:element ref="husstDV:VersionInhalt"/>
+      <xs:element ref="husstDV:VersionStruktur"/>
+      <xs:element ref="husstDV:Vias"/>
+      <xs:element ref="husstDV:Wege"/>
+      <xs:element ref="husstDV:Wegpositionen"/>
+      <xs:element ref="husstDV:Zeitraeume"/>
+      <xs:element ref="husstDV:Zeitraumoptionen"/>
+      <xs:element ref="husstDV:Zusatzsorten"/>
+    </xs:choice>
+  </xs:complexType>
+  
+  <xs:complexType name="SortengruppenElemente_Type">
+    <xs:annotation>
+      <xs:documentation>Sorten/Preisstufen Einträge einer Sortengruppe.</xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_SortengruppenElement"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarif"/>
+        <api:schema name="Angebot"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_SortengruppenElement" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Sortengruppe" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="SortOrder" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Sorte" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Preisstufe" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            ID_Preisstufe ist optional. Wenn die Preisstufe
+            angegeben ist, wird der Produkt als Festpreis
+            verkauft. Ansonsten
+            muss die Preisstufe aufgrund weiterer
+            Einschränkungen (z.b. Auswahl
+            einer Relation) ermittelt bzw.
+            festgelegt werden.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
@@ -864,16 +864,6 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="ID_Streckenverlauf" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
-        <xs:annotation>
-          <xs:documentation>
-            Die ID_Streckenverlauf ermöglicht das Matchen von einer Relation zu einer festgelegten Verbindung in Streckentarifen.
-             * wenn ID_TarifartStrecke nicht gesetzt ist, dann hat ID_Streckenverlauf keine Auswirkung,
-             * das Vertriebsgerät muss die durch den Streckenverlauf definierte Strecke parallel in der Streckenlogik suchen, wenn ID_Streckenverlauf gesetzt ist,
-             * das Vertriebsgerät muss parallel in der normalen Streckenlogik (kürzester Weg) suchen, wenn ID_Streckenverlauf nicht gesetzt ist.
-          </xs:documentation>
-        </xs:annotation>
-      </xs:element>
       <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
@@ -4978,19 +4968,19 @@
     </xs:sequence>
   </xs:complexType>
   
-  <xs:complexType name="Streckenverlauf_Type">
+  <xs:complexType name="StreckenverlaufStrecke_Type">
     <xs:annotation>
       <xs:documentation>
-        Ein richtungsgebundener Verlauf von Strecken, welcher eine Verbindung über mehrere explizit definierte Brechpunkte darstellt.
-        Die Strecken sind aneinandergereiht, so dass der ID_StreckencodeStart von Streckenverlauf n dem ID_StreckencodeZiel des Vorgängerdatensatzen n-1 entspricht.
+        Definiert die Zuordnung der Strecken zu einem Streckenverlauf.
+        Die Strecken sind aneinandergereiht, so dass der ID_StreckencodeStart von Strecke n dem ID_StreckencodeZiel des Vorgängerdatensatzes n-1 entspricht.
       </xs:documentation>
       <xs:appinfo>
         <api:primekey>
-          <api:field name="ID_StreckenverlaufDS"/>
+          <api:field name="ID_StreckenverlaufStrecke"/>
           <api:field name="ID_Zeitraum"/>
         </api:primekey>
         <api:schema name="Tarifstrecken"/>
-        <api:uniquekey name="Uix_Streckenverlauf">
+        <api:uniquekey name="Uix_StreckenverlaufStrecke">
           <api:field name="ID_Strecke"/>
           <api:field name="ID_Streckenverlauf"/>
           <api:field name="ID_Zeitraum"/>
@@ -5000,7 +4990,7 @@
     <xs:sequence>
       <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
       <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
-      <xs:element name="ID_StreckenverlaufDS" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_StreckenverlaufStrecke" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
       <xs:element name="ID_Streckenverlauf" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
       <xs:element name="ID_Strecke" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
       <xs:element name="IstStartBrechpunkt" type="xs:boolean" maxOccurs="1" minOccurs="1">
@@ -5018,6 +5008,61 @@
         </xs:annotation>
       </xs:element>
       <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Streckenverlauf_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Ein richtungsgebundener Verlauf von Strecken, welcher eine Verbindung über mehrere explizit definierte Brechpunkte darstellt.
+        Die Zuordnung der Strecken, aus denen der Verlauf besteht, befindet sich in StreckenverlaufStrecke.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Streckenverlauf"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckenverlauf" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Schlüssel des Tarifgebers für diesen Streckenverlauf.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="StreckenverlaufRelation_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Ordnet einen Streckenverlauf einer oder mehreren Relationen zu.
+        Das ermöglicht das Matchen von einer Relation zu festgelegten Verbindungen in Streckentarifen.
+          * wenn ID_TarifartStrecke an der Relation nicht gesetzt ist, dann hat diese Zuordnung  keine Auswirkung,
+          * das Vertriebsgerät muss die durch die Streckenverläufe definierten Verbindungen parallel in der Streckenlogik suchen,
+          * das Vertriebsgerät muss parallel in der normalen Streckenlogik (kürzester Weg) suchen, wenn kein Streckenverlauf zu der Relation zugewiesen ist.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Relation"/>
+          <api:field name="ID_Streckenverlauf"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Tarifstrecken"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Streckenverlauf" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Relation" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
   
@@ -5164,6 +5209,10 @@
   <xs:element name="Gleichstellung" type="husstDV:Gleichstellung_Type"/>
 
   <xs:element name="Streckenverlauf" type="husstDV:Streckenverlauf_Type"/>
+
+  <xs:element name="StreckenverlaufStrecke" type="husstDV:StreckenverlaufStrecke_Type"/>
+
+  <xs:element name="StreckenverlaufRelation" type="husstDV:StreckenverlaufRelation_Type"/>
   <!--Wurzel -->
   
   <xs:element name="OePVTarifDB" type="husstDV:OePVTarifDB_Type"/>
@@ -5230,6 +5279,8 @@
       <xs:element ref="husstDV:Strecke"/>
       <xs:element ref="husstDV:Streckencode"/>
       <xs:element ref="husstDV:Streckenverlauf"/>
+      <xs:element ref="husstDV:StreckenverlaufRelation"/>
+      <xs:element ref="husstDV:StreckenverlaufStrecke"/>
       <xs:element ref="husstDV:Streckenzuordnung"/>
       <xs:element ref="husstDV:TagesartMerkmalElemente"/>
       <xs:element ref="husstDV:Tagesarten"/>

--- a/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:husstDV="http://husst.de/Versorgungsdaten/3_8_0"
-           xmlns:api="http://www.husst.de/Appinfo/3_8_0"
+           xmlns:api="http://husst.de/Appinfo/3_8_0"
            targetNamespace="http://husst.de/Versorgungsdaten/3_8_0"
            elementFormDefault="qualified" attributeFormDefault="unqualified">
   <xs:include schemaLocation="./HUSST_DvBasis_3_8_0.xsd"/>
@@ -4857,7 +4857,7 @@
   <xs:complexType name="Streckenzuordnung_Type">
     <xs:annotation>
       <xs:documentation>
-        Ordnet eine Strecke einem oder mehreren Teilrelationen zu.
+        Ordnet eine Strecke einer oder mehreren Teilrelationen zu.
       </xs:documentation>
       <xs:appinfo>
         <api:primekey>
@@ -4982,19 +4982,25 @@
     <xs:annotation>
       <xs:documentation>
         Ein richtungsgebundener Verlauf von Strecken, welcher eine Verbindung über mehrere explizit definierte Brechpunkte darstellt.
+        Die Strecken sind aneinandergereiht, so dass der ID_StreckencodeStart von Streckenverlauf n dem ID_StreckencodeZiel des Vorgängerdatensatzen n-1 entspricht.
       </xs:documentation>
       <xs:appinfo>
         <api:primekey>
-          <api:field name="ID_Strecke"/>
-          <api:field name="ID_Streckenverlauf"/>
+          <api:field name="ID_StreckenverlaufDS"/>
           <api:field name="ID_Zeitraum"/>
         </api:primekey>
         <api:schema name="Tarifstrecken"/>
+        <api:uniquekey name="Uix_Streckenverlauf">
+          <api:field name="ID_Strecke"/>
+          <api:field name="ID_Streckenverlauf"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:uniquekey>
       </xs:appinfo>
     </xs:annotation>
     <xs:sequence>
       <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
       <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_StreckenverlaufDS" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
       <xs:element name="ID_Streckenverlauf" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
       <xs:element name="ID_Strecke" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
       <xs:element name="IstStartBrechpunkt" type="xs:boolean" maxOccurs="1" minOccurs="1">
@@ -5011,6 +5017,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
     </xs:sequence>
   </xs:complexType>
   

--- a/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_DvTarifAngebot_3_8_0.xsd
@@ -4998,7 +4998,7 @@
       <xs:element name="ID_StreckencodeVerlauf" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
       <xs:element name="ID_Streckencode" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
       <xs:element name="IstViapunkt" type="xs:boolean" maxOccurs="1" minOccurs="1">
-      <xs:annotation>
+        <xs:annotation>
           <xs:documentation>
             Gibt an, ob der Streckencode eine Relevanz bei der Streckensuche hat.
           </xs:documentation>

--- a/Version 3/3.8.0/HUSST_DvVertrieb_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_DvVertrieb_3_8_0.xsd
@@ -1,0 +1,490 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:husstDV="http://husst.de/Versorgungsdaten/3_8_0"
+           xmlns:api="http://www.husst.de/Appinfo/3_8_0"
+           targetNamespace="http://husst.de/Versorgungsdaten/3_8_0"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <xs:include schemaLocation="./HUSST_DvBasis_3_8_0.xsd"/>
+  
+  <xs:annotation>
+    <xs:documentation>
+      HUSST Versorgungsdaten - Schema: Personal (verwendet Basisversorgungsdaten)
+      Version: 3.8.0
+
+      Mehr Informationen:
+      - https://husst.de/
+      - https://github.com/HUSST-de/HUSST
+
+      Lizensiert unter CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
+    </xs:documentation>
+  </xs:annotation>
+  
+  <xs:element name="husstPersonal" type="husstDV:husstPersonal_Type"></xs:element>
+  
+  <xs:element name="DefIdentobjekttyp" type="husstDV:DefIdentobjekttyp_Type" />
+  <xs:element name="DefPasswortHashtyp" type="husstDV:DefPasswortHashtyp_Type" />
+  <xs:element name="Einsatzarten" type="husstDV:Einsatzarten_Type" />
+  <xs:element name="Geraetetypen" type="husstDV:Geraetetypen_Type" />
+  <xs:element name="Geraet" type="husstDV:Geraet_Type" />
+  <xs:element name="GeraeteEinsatztypen" type="husstDV:GeraeteEinsatztypen_Type" />
+  <xs:element name="Identobjekte" type="husstDV:Identobjekte_Type" />
+  <xs:element name="PersonalIdentobjekte" type="husstDV:PersonalIdentobjekte_Type" />
+  <xs:element name="Personal" type="husstDV:Personal_Type" />
+  <xs:element name="Personaleinsatz" type="husstDV:Personaleinsatz_Type" />
+
+
+  <xs:complexType name="husstPersonal_Type">
+    <xs:choice maxOccurs="unbounded">
+      <xs:element ref="husstDV:Bearbeitung" />
+      <xs:element ref="husstDV:Interpretationen" />
+      <xs:element ref="husstDV:Unternehmen" />
+      <xs:element ref="husstDV:Updateinfo" />
+      <xs:element ref="husstDV:VersionInhalt" />
+      <xs:element ref="husstDV:VersionStruktur" />
+      <xs:element ref="husstDV:Zeitraeume" />
+      <xs:element ref="husstDV:Zeitraumoptionen" />
+  
+      <xs:element ref="husstDV:DefIdentobjekttyp" />
+      <xs:element ref="husstDV:DefPasswortHashtyp"/>
+      <xs:element ref="husstDV:Einsatzarten" />
+      <xs:element ref="husstDV:Geraetetypen"/>
+      <xs:element ref="husstDV:Geraet" />
+      <xs:element ref="husstDV:GeraeteEinsatztypen" />
+      <xs:element ref="husstDV:Identobjekte" />
+      <xs:element ref="husstDV:PersonalIdentobjekte" />
+      <xs:element ref="husstDV:Personal" />
+      <xs:element ref="husstDV:Personaleinsatz" />
+    </xs:choice>
+  </xs:complexType>
+
+  <xs:complexType name="Personal_Type">
+    <xs:annotation>
+      <xs:documentation>Personalstammdaten</xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Personal"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Personal"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Personal" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Unternehmen" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_AbrUnternehmen" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Abrechnungs-Unternehmen, bei dem Einnahmen abgeliefert werden müssen</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_PasswortHashtyp" type="husstDV:ID_PasswortHashtyp_Type" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Definiert die Art des Passworthashes</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Passwort" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Gehashtes Passwort. 
+            Wenn angegeben, ist ID_PasswortHashtyp zwingen anzugeben
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="Vorname" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="Nachname" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="GueltigAb" type="husstDV:DateTimeCompact" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="GueltigBis" type="husstDV:DateTimeCompact" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="ID_PasswortHashtyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_PasswortHashtyp ist entweder eine von HUSST vordefinierte Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_PasswortHashtypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+
+  <xs:complexType name="Personaleinsatz_Type">
+    <xs:annotation>
+      <xs:documentation>Geräte- und Rollenzuordnung zu Personal</xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Personaleinsatz"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Personal"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Personaleinsatz" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Personal" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Geraetetyp" type="xs:string" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_GeraeteEinsatztyp" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_EinsatzArt" type="husstDV:INT4" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Rolle, die er auf dem Gerätetyp einnimmt
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="ID_Identobjekttyp_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die ID_Identobjekttyp ist entweder eine von HUSST vordefinierte Zahl kleiner 1000 oder eine im Projekt vereinbarte Zahl größer gleich 1000.
+        Im freidefinierbaren Bereich gibt es herstellerspezifische Wertebereiche. s. https://github.com/HUSST-de/HUSST/tree/master/Version%203/3.0
+      </xs:documentation>
+    </xs:annotation>
+    <xs:union memberTypes="husstDV:ID_IdentobjekttypHUSST_Type husstDV:ID_Projektspezifisch_Type"/>
+  </xs:simpleType>
+
+  <xs:complexType name="Identobjekte_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Ident Objekte zur Identifizierung einer Person.
+        Die ID des Identobjektes ist über alle Objekttypen und Mandanten
+        eindeutig zu halten.
+
+        Idealerweise sollten alle Identobjekte eines Objekttyps über alle Mandanten im
+        System eindeutig sein.
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Identobjekt"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Personal" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Identobjekt" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Identobjekttyp" type="husstDV:ID_Identobjekttyp_Type" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Freier Text, der z.B. zur Anzeige verwendet werden kann.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Unternehmen" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Systemweit eindeutige Nummer/Kennung des Ident-Objektes
+            z.B. zusammengesetzt aus ID_Identobjekttyp und Identobjekt_Schluessel
+            ggf. mit ID_Unternehmen
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" minOccurs="0" maxOccurs="unbounded"/>
+      </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="PersonalIdentobjekte_Type">
+    <xs:annotation>
+      <xs:documentation>
+        PersonalIdentobjekte weist einer Person kein, ein oder mehrere Identobjekte zu.
+        Hinweis: Es handelt sich um eine n:m Beziehung. Auf einen künstlichen Schlüssel wird verzichtet.
+        Die Struktur hat deshalb keinen PrimeKey!
+
+        Einer Person kann ein Identobjekt auch mehrfach zugeordnet sein, mit unterschiedlichen
+        GueltigAb, GueltigBis Intervallen. Ein Identobjekt darf immer dann zur Identifikation verwendet werden,
+        wenn bei mindestens einem Zuordnungsobjekt der aktuelle Systemzeitpunkt
+        im GueltigAb,GueltigBis Intervall liegt. Ist GueltigAb nicht angegeben,
+        gilt die Zuordnung ab "schon immer", ist GueltigBis nicht angegeben
+        gilt die Zuordnung "bis ewig".
+      </xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_PersonalIdentobjekt"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Personal" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_PersonalIdentobjekt" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Identobjekt" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Personal" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="GueltigAb" type="husstDV:DateTimeCompact" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Wenn angegeben, definiert GueltigAb den Beginn der Verwendbarkeit des Ident-Objektes.
+            Vor diesem Zeitpunkt darf sich der Bediener mit diesem Objekt nicht erfolgreich am System anmelden können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="GueltigBis" type="husstDV:DateTimeCompact" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Wenn angegeben, definiert GueltigBis das Ende der Verwendbarkeit des Ident-Objektes.
+            Nach diesem Zeitpunkt darf sich der Bediener mit diesem Objekt nicht erfolgreich am System anmelden können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Geraet_Type">
+    <xs:annotation>
+      <xs:documentation>Geräteverwaltung</xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Geraet"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Personal" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Geraet" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Geraetetyp" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="KA_KvpOrgID" type="husstDV:INT4" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>KA KVP Nr</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Unternehmen" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="GeraeteEinsatztypen_Type">
+    <xs:annotation>
+      <xs:documentation>Zur Differenzierung der Datenverteilung</xs:documentation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_GeraeteEinsatztyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Personal" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_GeraeteEinsatztyp" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Geraetetypen_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Geraetetyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Personal"/>
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_Geraetetyp" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1" />
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Referenz zu einem extern definierten Element.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="Einsatzarten_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_EinsatzArt"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Personal" />
+      </xs:appinfo>
+      <xs:documentation>Personaleinsatz Beschreibung
+- Verkäufer
+- Kontrolleur
+- Zugbegleiter</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="ID_EinsatzArt" type="husstDV:INT4" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Referenz zu einem extern definierten Element.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="ID_Geraetetyp" type="husstDV:INT4" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefIdentobjekttyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_Identobjekttyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Personal"/>
+      </xs:appinfo>
+      <xs:documentation>Definiert einen Identifikationstyp zur Anmeldung.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_Identobjekttyp" type="husstDV:ID_Identobjekttyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="DefPasswortHashtyp_Type">
+    <xs:annotation>
+      <xs:appinfo>
+        <api:primekey>
+          <api:field name="ID_PasswortHashtyp"/>
+          <api:field name="ID_Zeitraum"/>
+        </api:primekey>
+        <api:schema name="Personal"/>
+      </xs:appinfo>
+      <xs:documentation>Definiert einen Hashtyp zum vergleichen von Passwörtern.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="Deaktiviert" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ID_Zeitraum" type="husstDV:INT4" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="ID_PasswortHashtyp" type="husstDV:ID_PasswortHashtyp_Type" maxOccurs="1" minOccurs="1"/>
+      <xs:element name="Bezeichnung" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="ReferenzExtern" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Dient als Referenz um extern definierte Elemente über einen ggf. auch nicht numerischen Schlüssel
+            identifizieren zu können.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="DynAttribut" type="husstDV:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </xs:sequence>
+  </xs:complexType>
+
+   <xs:simpleType name="ID_IdentobjekttypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert ID_Identobjekttypen kleiner 1000
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>nicht spezifiziert/unbestimmt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>Fahrermodul</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>Chipkarte</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>Schlüssel</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>Anmeldecode</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+   <xs:simpleType name="ID_PasswortHashtypHUSST_Type">
+    <xs:annotation>
+      <xs:documentation>
+        Die HUSST definiert PasswortHashTypen kleiner 1000
+
+        Die Verfahren 1 bis 4 entsprechen der Empfehlung
+        https://en.wikipedia.org/wiki/Key_derivation_function
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="husstDV:INT4">
+      <xs:enumeration value="0">
+        <xs:annotation>
+          <xs:documentation>Klartext</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="1">
+        <xs:annotation>
+          <xs:documentation>argon2id</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="2">
+        <xs:annotation>
+          <xs:documentation>scrypt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="3">
+        <xs:annotation>
+          <xs:documentation>bcrypt</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="4">
+        <xs:annotation>
+          <xs:documentation>PBKDF2</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>

--- a/Version 3/3.8.0/HUSST_Ergebnisdaten_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_Ergebnisdaten_3_8_0.xsd
@@ -1,0 +1,2709 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema targetNamespace="http://husst.de/Ergebnisdaten/3_8_0" elementFormDefault="qualified"
+        xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:husst="http://husst.de/Ergebnisdaten/3_8_0">
+
+  <annotation>
+    <documentation>
+      HUSST Ergebnisdaten
+      Version: 3.8.0
+
+      Mehr Informationen:
+      - https://husst.de/
+      - https://github.com/HUSST-de/HUSST
+
+      Lizensiert unter CC BY-SA 4.0 (https://creativecommons.org/licenses/by-sa/4.0/)
+    </documentation>
+  </annotation>
+
+  <complexType name="Any_Type">
+    <choice>
+      <element name="StringData" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="BinaryData" type="base64Binary" maxOccurs="1" minOccurs="0"/>
+    </choice>
+  </complexType>
+
+  <complexType name="Ausgabeabschnitt_Type">
+    <annotation>
+      <documentation>
+        Definiert einen Papierabschnitt mit seiner Startnummer
+        und der Anzahl seiner Barcodeabschnitte oder Abschnittzähler. Die Startnummer
+        ist immer die kleinste Nummer des gelesenen Abschnittes,
+        egal in welche Richtung die Nummerierung der Rolle geht.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="StartNr" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>Startnummer des Abschnittzählers, z.B. Barcode oder anfängliche Rollennummer.</documentation>
+        </annotation>
+      </element>
+      <element name="Anzahl" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Anzahl der Abschnittzähler, z.B. Barcodes</documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="Typ" type="husst:AusgabeabschnittTyp_Type" use="required">
+      <annotation>
+        <documentation>Der Typ des Papierdokumentes</documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Barbezahlung_Type">
+    <sequence>
+      <element name="Einnahme" type="husst:Betrag_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Rueckgabe" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Bargeldbilanz_Type">
+    <annotation>
+      <documentation>
+        Für jede vorkommende Währung werden hier die Bilanzen
+        über den Dienst, der bei Automaten gleiche mit der Schicht ist,
+        aufgeführt. Die zugehörigen Bargeld-Einnahmen finden sich in der
+        Kassenliste.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="Anfangsbestand" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="1"/>
+      <element name="Zufuehrungen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Entnahmen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Fehleinnahmen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Kassenentnahmen" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Endbestand" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Beleg_Type">
+    <sequence>
+      <element name="BelegNr" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Laufende Aufdrucknummer auf einem Papierdokument oder gespeicherte
+            Folgenummer
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Abschnitt" type="husst:Ausgabeabschnitt_Type" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Zugehörige, unveränderliche Dokumentmerkmale. (Abschnittzähler oder rückseitiger Barcode)</documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="Typ" type="husst:BelegTyp_Type" use="required"/>
+  </complexType>
+
+  <complexType name="Belegkasse_Type">
+    <sequence>
+      <element name="Betrag" type="husst:Betrag_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Hier kann der Gesamtbetrag der vereinnahmten
+            Belege eingetragen werden
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Gutschrift" type="husst:Tarifprodukt_Type" minOccurs="0" maxOccurs="1"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="Typ" type="husst:BelegkasseTyp_Type" use="required"/>
+    <attribute name="Anzahl" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="Belegkassenliste_Type">
+    <sequence>
+      <element name="BelegKasse" type="husst:Belegkasse_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Betrag_Type">
+    <sequence>
+      <element name="Waehrung" type="husst:Waehrung_Type"/>
+      <element name="Betrag" type="int">
+        <annotation>
+          <documentation>
+            Betrag in kleinsten Währungseinheiten (z.B. Euro-Cent)
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+
+  <complexType name="Datensatz_Type">
+    <choice>
+      <element name="Schichtbeginn" type="husst:Schichtbeginn_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Schichtabschluss" type="husst:Schichtabschluss_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Pruefbeginn" type="husst:Pruefbeginn_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Pruefabschluss" type="husst:Pruefabschluss_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Komponentenliste" type="husst:Komponentenliste_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Meldung" type="husst:Meldung_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Ausgabeabschnitt" type="husst:Ausgabeabschnitt_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Transaktionsdaten" type="husst:Transaktionsdaten_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Fahrtverlauf" type="husst:Fahrtverlauf_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Dienstbeginn" type="husst:Dienstbeginn_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Dienstende" type="husst:Dienstende_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Kontrolldaten" type="husst:Kontrolldaten_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Geldbehaelterliste" type="husst:Geldbehaelterliste_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Warenkorb" type="husst:Warenkorb_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="EBEErfassung" type="husst:EBEErfassung_Type" maxOccurs="1" minOccurs="1"/>
+    </choice>
+    <attribute name="Zeitpunkt" type="dateTime" use="required">
+      <annotation>
+        <documentation>
+          Der jeweilge Zeitpunkt der Generierung des
+          Datenatzes.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="DsNr" type="int" use="required">
+      <annotation>
+        <documentation>
+          Eine fortlaufende ununterbrochene Nummer innerhalb
+          der Schicht. Die '0' sollte ausgenommen werden.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Dienstbeginn_Type">
+    <sequence>
+      <element name="Vertriebsstelle" type="husst:Vertriebsstelle_Type" minOccurs="1" maxOccurs="unbounded">
+        <annotation>
+          <documentation>
+            Der Dienstbeginn kann gleichzeitig auf mehrere
+            Vertriebsstellen bezogen sein. Hiermit besteht
+            beispielsweise die Möglichkeit geichzeitig auf
+            den Verkäufer und die Verkaufsstelle zu
+            beziehen.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="DienstPlanNr" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Die laufende Bezeichnung des Dienstplans des
+            Gerätebedieners.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required">
+      <annotation>
+        <documentation>
+          Diese Dienstnummer enstpricht der den Anwendern
+          bekannte Dienstnummer.
+          In der Regel wird nach dieser Nummer ausgewertet
+          und die Nummer wird auf Belege aufgedruckt.
+          Die Dienstnummer ist mindestens für jede Schicht eindeutig.
+          Eine Schicht kann viele Dienste enthalten.
+          Die Dienstnummer sollte inkrementierend aufsteigen und nie '0' sein.
+
+          Achtung: Schichtnummer vs. Dienstnummer:
+          Innerhalb einer Schicht können mehrere Dienste
+          auch gleichzeitig ablaufen.
+          Kein Dienst überlappt zeitlich eine Schichtgrenze.
+          Dienste sind in der Regel Personen-(Konten) oder
+          Geräte-(Konten) zugeordnet.
+          Schichten sind nur ein Behälter für
+          Dienste und sonstige Informationen, die
+          keinem Dienst zugeordnet sind.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Dienstende_Type">
+    <sequence>
+      <element name="Vertriebsstelle" type="husst:Vertriebsstelle_Type" maxOccurs="unbounded" minOccurs="1"/>
+      <element name="Beleg" type="husst:Beleg_Type" minOccurs="0" maxOccurs="unbounded"/>
+      <element name="Kassenliste" type="husst:Kassenliste_Type" minOccurs="1" maxOccurs="1"/>
+      <element name="Belegkassenliste" type="husst:Belegkassenliste_Type" minOccurs="1" maxOccurs="1"/>
+      <element name="Bargeldbilanz" type="husst:Bargeldbilanz_Type" minOccurs="0" maxOccurs="1"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="DynAttribut_Subtype">
+    <annotation>
+      <documentation>
+        Der Subtyp DynAttribut_Subtype dient der Definition von
+        dynamischen Attributen als mögliche Erweiterung für die
+        Xml-Darstellung der Daten. Der Subtyp wird nicht 1:1 für
+        eine Abbildung auf ein relationales Datenbankmodell
+        verwendet.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="Name" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Wert" type="string" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="EBEErfassung_Type">
+    <sequence>
+      <element name="BezugsNr" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Eine eindeutige ID dieses EBE-Vorgangs, es
+            könnte bei Verkaufsgeräten die UID sein, bei
+            Nacherfassung muss die ID vom Bediener
+            versorgt werden.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="EBEVorgang" type="husst:EBEVorgang_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Merkmale" type="husst:EBEMerkmale_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Kundendaten" type="husst:Kundendaten_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Verfolgung" type="husst:Verfolgung_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="EBEMerkmale_Type">
+    <sequence>
+      <element name="Ort" type="husst:Transaktionsort_Type" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eine Erfassung des Vorgangsorts.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="VorfallsOrtNotiz" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eine textuelle Beschreibung des Vorfallsorts.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="KomfortKlasse" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="Fahrausweisart" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Wenn ein Fahrausweis vorgezeigt wurde, welcher Art
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrausweisNr" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Die Nummer (laufende Nummer) des Fahrausweises
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrausweisEingezogen" type="boolean" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Wird auf true gesetzt, wenn der Fahrausweis eingezogen wurde.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrausweisAbholung" type="date" maxOccurs="1" minOccurs="0"/>
+      <element name="Bearbeitungsstelle" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="EinstiegsHaltestelle" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Die IBNR</documentation>
+        </annotation>
+      </element>
+      <element name="EinstiegNotiz" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eine textuelle Beschreibung zum Einstieg
+          </documentation>
+        </annotation>
+      </element>
+      <element name="ZielHaltestelle" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Die IBNR</documentation>
+        </annotation>
+      </element>
+      <element name="ZielNotiz" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eine textuelle Beschreibung zum Fahrtziel bzw. Ausstieg
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Codierung" type="husst:Codierung_Type" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Eine Codierung zur Angabe des Grunds zum EBE-Fall
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Sitzplatz" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Ein Hinweis, wo der EBE-Fall angetroffen wurde
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Verhalten" type="string" maxOccurs="unbounded" minOccurs="0">
+        <annotation>
+          <documentation>
+            Bemerkungen zu Verhalten des EBE-Falls.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Polizei" type="husst:Polizei_Type" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Wenn Polizei hinzugezogen wurde, von welchem Revier.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Linie" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="Kurs" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="Verbundkennung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+
+  <complexType name="EBEVorgang_Type">
+    <sequence>
+      <element name="Typ" type="husst:VorgangsTyp_Type" maxOccurs="unbounded" minOccurs="1"/>
+      <element name="Beanstandung" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Entspricht der vorgegebenen Codierung z.B. der
+            Bahn, in der Regel eine zweistellige Ziffer.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Begruendung" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Der Grund der Beanstandung (zB. nicht lesbar, vermutlich verfälscht, Tarif ungültig, ohne Kundenkarte etc.)
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Forderung" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Referenzbetrag" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="EinsatzTyp_Type">
+    <sequence>
+      <element name="Name" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Der Name ist ein beliebiger, sprechender Name des
+            Einsatztyps (z.B. Vorverkauf, Bereich Hamburg Mitte).
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+    <attribute name="Nr" type="int">
+      <annotation>
+        <documentation>
+          Einsatztypen unterscheiden im Gegensatz zu Geräten den jeweiligen Einsatz des Gerätes.
+          So kann ein gleiches technisches Gerät sowohl mobil als auch
+          stationär mit unterschiedlichen Ausprägungen betrieben werden.
+
+          Die Einsatztypennummer entspricht der dem Anwender bekannten Einsatztypennummer.
+          Der Standard-Einsatztyp ist '1'.
+
+          Die Einsatztypennummer ist nur zusammen mit der Angabe
+          eines Mandanten eindeutig.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="Mandant" type="int">
+      <annotation>
+        <documentation>
+          Die Einsatztypennummer ist nur zusammen mit einem
+          zugeordneten Mandant eindeutig.
+          Der Standard-Mandant ist '1'.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Fahrtverlauf_Type">
+    <annotation>
+      <documentation>Diese Datensätze beinhalten, abweichend von anderen Datensätzen, Information aus betrieblichen VDV452 Daten.</documentation>
+    </annotation>
+    <sequence>
+      <element name="Betrieb" type="husst:INT4" minOccurs="1" maxOccurs="1">
+        <annotation>
+          <documentation>
+            REC_FRT.BETRIEB aus VDV bei Mandantensystemen, sonst 0.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrzeugNr" type="husst:INT4" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Nach VDV FAHRZEUG.FZG_NR
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrzeugUnr" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Nummer des Unternehmens, dem das Fahrzeug gehört. FAHRZEUG.ABK_UNTERNEHMEN
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrerNr" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Nch VDV: PERSONAL.FAHRER_NR</documentation>
+        </annotation>
+      </element>
+      <element name="FahrerUnr" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Nach VDV: PERSONAL.ABK_UNTERNEHMEN -> TEILNEHMER.UNTERNEHMEN
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrtID" type="husst:INT4" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Fahrtnummer der Fahrt laut VDV REC_FRT.FRT_ID
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Fahrt" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Optionale Kennung der Fahrt als Text.</documentation>
+        </annotation>
+      </element>
+      <element name="LinieID" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Nach VDV: Aus der Tabelle REC_LID.LI_NR
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Linie" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Optionale Linieninformation als Text. Optional REC_LID.LIDNAME oder REC_LID.LI_KUERZEL</documentation>
+        </annotation>
+      </element>
+      <element name="Richtung" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Nach VDV: REC_LID.LI_RI_NR
+          </documentation>
+        </annotation>
+      </element>
+      <element name="FahrplanLage" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Fahrplanlage in Sekunden, negative Werte für Verfrühung.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="OrtTyp" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Nach VDV: REC_ORT.ONR_TYP_NR</documentation>
+        </annotation>
+      </element>
+      <element name="OrtNr" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Haltepunktnummer nach VDV: REC_ORT.ORT_NR
+          </documentation>
+        </annotation>
+      </element>
+      <element name="HpEntfernung" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Entfernung zum Haltepunkt in Metern, 0 = Haltepunkt, positiv: vor Haltepunkt
+          </documentation>
+        </annotation>
+      </element>
+      <element name="TuerOffen" type="boolean" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            false: Alle Türen sind am HP geschlossen.
+            true: mindestens eine Türe ist offen.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="HaltepunktDurch" type="boolean" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            false: Fahrzeug hat am Haltepunkt gehalten.
+            true: der Haltepunkt wurde durchfahren.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Haltezeit" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Haltezeit am Haltepunkt in Sekunden.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="HaltestelleBedarf" type="boolean" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Gibt an, ob die Haltestelle eine reguläre oder
+            eine Bedarfshaltestelle ist. false= reguläre
+            Haltestelle, true = Bedarfshaltestelle
+          </documentation>
+        </annotation>
+      </element>
+      <element name="TachoStand" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Tachostand in Metern.</documentation>
+        </annotation>
+      </element>
+      <element name="Koordinate" type="husst:KoordWgs84_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="ZaehldatenListe" type="husst:Zaehldatenliste_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="Datenversion" type="int" use="required">
+      <annotation>
+        <documentation>
+          Versionsnummer des Fahrplans, auf den sich dieser Datensatz bezieht.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Geldbehaelter_Type">
+    <sequence>
+      <element name="Stueck" type="husst:Stuecke_Type" minOccurs="0" maxOccurs="unbounded"/>
+      <element name="Wert" type="husst:Betrag_Type" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+    <attribute name="Typ" type="husst:GeldbehaelterTyp_Type"/>
+    <attribute name="Nr" type="int">
+      <annotation>
+        <documentation>Behälternummer</documentation>
+      </annotation>
+    </attribute>
+    <attribute name="PhysPosition" type="int" use="optional">
+      <annotation>
+        <documentation>
+          Die physikalische Position
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Geldbehaelterliste_Type">
+    <annotation>
+      <documentation>notiert die Geldwerte oder sonstige Werte (Gutscheine, Stornierungsbelege, ...) bezogen auf einen Vorgangszeitpunkt</documentation>
+    </annotation>
+    <sequence>
+      <element name="Vorgang" type="husst:GeldBehaeltervorgang_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Geldbehaelter" type="husst:Geldbehaelter_Type" minOccurs="0" maxOccurs="unbounded"/>
+      <element name="Wertbehaelter" type="husst:Wertbehaelter_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="Geraet_Type">
+    <sequence>
+      <element name="Name" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Der Name ist ein beliebiger, sprechender Name des
+            Gerätes. (z.B. Busdrucker-1234).
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Id" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eindeutige Kennung eines Bestandteils der
+            Gerätehardware (z.B. die MAC der Netzwerkhardware.) Welche Kennung
+            das ist, muss von der Gerätesoftware entschieden werden. Das
+            Element ist optional.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+    <attribute name="Typ" type="string" use="required">
+      <annotation>
+        <documentation>
+          Der Gerätetyp entspricht den Anwendern bekannten und vorgegebenen Namen.
+          Die Liste der Gerätetypen kann beliebig erweitert werden.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="Nr" type="int" use="required">
+      <annotation>
+        <documentation>
+          Die Nummer entspricht der dem Anwender bekannten Gerätenummer.
+          Die Nummer ist nur zusammen mit der Angabe eines
+          Mandanten eindeutig.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="Mandant" type="int" use="required">
+      <annotation>
+        <documentation>
+          Die Gerätenummer ist nur zusammen mit einem
+          zugeordneten Mandant eindeutig.
+          Der Standard-Mandant ist '1'.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Gutscheinbezahlung_Type">
+    <sequence>
+      <element name="GutschId" type="husst:Tarifprodukt_Type" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>Eindeutige Kennung des Gutscheintyps</documentation>
+        </annotation>
+      </element>
+      <element name="Nr" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="KAReferenz_Type">
+    <sequence>
+      <element name="SamNummer" type="husst:INT3" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            SAM_ID.samNummer 24 Bit (Beispiel 0x654321), eine, im
+            gesamten Geltungsbereich der Kernapplikation eindeutige
+            SAM-Kartennummer
+          </documentation>
+        </annotation>
+      </element>
+      <element name="SamSequenznummer" type="husst:INT4" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            samSequenznummer 32 Bit (Beispiel 0x789ABCDE),
+            eindeutige, fortlaufende Nummer die von einer
+            SAM-Karte generiert wird.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+
+  <complexType name="Kasse_Type">
+    <sequence>
+      <element name="Betrag" type="husst:Betrag_Type" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Kassenstand in kleinster Waehrungseinheit (z.B. Cent, Rappen, etc.)
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Zahlart" type="husst:BezahlArt_Type" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Kassenliste_Type">
+    <sequence>
+      <element name="Kasse" type="husst:Kasse_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="KKOfflineBezahlung_Type">
+    <sequence>
+      <element name="Kartenherausgeber" type="husst:BezahlArt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="KartenNr" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Pruefkennung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="GueltigBis" type="gYearMonth" maxOccurs="1" minOccurs="1"/>
+      <element name="Unterschrift" type="boolean" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Komponente_Type">
+    <sequence>
+      <element name="Name" type="string" minOccurs="1" maxOccurs="1"/>
+      <element name="Version" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Variante" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="SerienNr" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="PhysPosition" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="ErstellZeitPunkt" type="dateTime" maxOccurs="1" minOccurs="0"/>
+      <element name="Hersteller" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Komponente" type="husst:Komponente_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+    <attribute name="Klasse" type="husst:KomponentenKlasse_Type" use="required"/>
+  </complexType>
+
+  <complexType name="Komponentenliste_Type">
+    <sequence>
+      <element name="Vorgang" type="husst:KomponentenVorgang_Type"/>
+      <element name="Komponente" type="husst:Komponente_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Kontrolldaten_Type">
+    <annotation>
+      <documentation></documentation>
+    </annotation>
+    <sequence>
+      <element name="Typ" maxOccurs="1" minOccurs="1" type="string">
+        <annotation>
+          <documentation>Kontrollmeldungen beliebiger Art z. B. Chipkartenkontrolle für KA-Berechtigung, DB-Online-Ticket, BOB-Ticket, DF-Fahrschein, ...</documentation>
+        </annotation>
+      </element>
+      <element name="Kontrolldaten" type="husst:Any_Type" maxOccurs="1" minOccurs="1"/>
+      <choice>
+        <element name="KAReferenz" type="husst:KAReferenz_Type" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen KA Kontrolldaten enthalten.
+            </documentation>
+          </annotation>
+        </element>
+        <element name="Referenz" type="string" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen Transaktionsdaten als
+              Eindeutigkeitskennzeichen enthalten.
+            </documentation>
+          </annotation>
+        </element>
+      </choice>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="Kundendaten_Type">
+    <sequence>
+      <element name="Fahrgast" type="husst:Person_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Erzieher" type="husst:Person_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Lastschrift_Type">
+    <sequence>
+      <element name="BLZ-BIC" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Konto-IBAN" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="KartenfolgeNr" type="int" maxOccurs="1" minOccurs="1"/>
+      <element name="Kartenart" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>1=ec-Karte Magnetstreifen</documentation>
+        </annotation>
+      </element>
+      <element name="GueltigBis" type="gYearMonth" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>Gültigendejahr der Karte</documentation>
+        </annotation>
+      </element>
+      <element name="Unterschrift" type="boolean" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Meldung_Type">
+    <annotation>
+      <documentation>
+        Dieser Datensatz dient der Aufnahme von Textmeldungen beliebiger Art.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="Nr" type="int" minOccurs="1" maxOccurs="1"/>
+      <element name="MeldModTyp" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>Typ des meldunggenerierenden Moduls</documentation>
+        </annotation>
+      </element>
+      <element name="Komponente" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Komponentenbezeichnung</documentation>
+        </annotation>
+      </element>
+      <element name="PhysPosition" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Eine unterscheidende, physikalische Position, wenn mehrere gleiche Komponenten Meldungen emmitieren.</documentation>
+        </annotation>
+      </element>
+      <element name="Text" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Meldungstext, Entwicklertext. Dieser Text wird in
+            der Regel vor der Anzeige ersetzt.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Attribut" type="string" maxOccurs="unbounded" minOccurs="0">
+        <annotation>
+          <documentation>
+            Kommagetrennte Attribute die für eine
+            Meldungstextgenerierung benötigt werden:
+
+            Format('User "%s" was sleeping between %s and
+            %s',[Attribute])
+
+            So dass auch bei sprachvarianten Anzeigen
+            dynamische Inhalte ausgegeben werden können.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+    <attribute name="Klasse" type="husst:Meldungsklasse_Type" use="required"/>
+  </complexType>
+
+  <complexType name="Mitnahme_Type">
+    <sequence>
+      <element name="Fahrgasttyp" type="husst:KundenTyp_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Anzahl" type="int" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Ortspunkt_Type">
+    <sequence>
+      <element name="ID_Ortspunkt" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="ReferenzExtern" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Person_Type">
+    <sequence>
+      <element name="Vorname" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Nachname" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Namenszuatz" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="StrasseHausNr" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Postleitzahl" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Laenderkennzeichen" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Wohnort" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Staat" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Geschlecht" maxOccurs="1" minOccurs="0">
+        <simpleType>
+          <restriction base="string">
+            <enumeration value="weiblich"/>
+            <enumeration value="maennlich"/>
+          </restriction>
+        </simpleType>
+      </element>
+      <element name="TelefonNr" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Geburtsdatum" type="dateTime" maxOccurs="1" minOccurs="0"/>
+      <element name="Staatsangehoerigkeit" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Legitimtation" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Beschreibung der legitimation, Ausweis, EC-Karte, etc.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="LegitimationNr" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Ausweisnummer</documentation>
+        </annotation>
+      </element>
+      <element name="LegitimationsDatum" type="dateTime" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Ausstellungsdateum der Legitimation
+          </documentation>
+        </annotation>
+      </element>
+      <element name="LegimitationsLand" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Ausstellungsland der Legitimation
+          </documentation>
+        </annotation>
+      </element>
+      <element name="LegitimationBild" type="boolean" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Auf der Legitimation war ein Lichtbild, das
+            Lichtbild wurde dem EBE-Fall zugeordnet
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Polizei_Type">
+    <sequence>
+      <element name="Dienstnummer" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Vorname" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Nachname" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Dienststelle" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Preis_Type">
+    <annotation>
+      <documentation>
+        Wenn keine Preisspalte angegeben ist, wird von der
+        Standardspalte "1" ausgegangen. Ansonsten muss die Nummer der
+        zugehörigen Preisspalte der Datenversorgung angegeben.
+        Die Kennung kann optional die Kennung der Preisspalte enthalten.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="Betrag" type="husst:Betrag_Type" minOccurs="1" maxOccurs="1"/>
+      <element name="ID_Mwst" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+      <element name="MwstSatz" maxOccurs="1" minOccurs="1" type="husst:FLOAT1">
+        <annotation>
+          <documentation>
+            Wert zwischen 0 und 100
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+    <attribute name="Verrechnung" type="husst:Preisverrechnung_Type" use="required"/>
+  </complexType>
+
+  <complexType name="ProdFahrschein_Type">
+    <annotation>
+      <documentation>
+        Via = Eine Liste von Tarifpunkten
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="ZeitVon" type="dateTime" maxOccurs="1" minOccurs="1"/>
+      <element name="ZeitBis" type="dateTime" maxOccurs="1" minOccurs="0"/>
+      <element name="Von" type="husst:Transaktionsort_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Nach" type="husst:Transaktionsort_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Via" type="husst:Transaktionsort_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="ID_Relation" type="husst:INT4" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Bezug auf die ID_Relation der Versorgungsdaten -
+            die Datenversion ist identisch mit der in dem
+            Tarifprodukt hinterlegten Datenversion
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Komfortklasse" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Rabattklasse" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="Mitnahme" type="husst:Mitnahme_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Teilrelation" type="husst:Teilrelation_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Produkt_Type">
+    <annotation>
+      <documentation>
+        Bei der Anwendung von Teilrelationen zur Aufteilung
+        von Fremd- und Eigenleistungen wird wie folgt vorgegangen:
+        Das
+        verkaufte Produkt wird als Hauptprodukt mit der Id und ExtId
+        'anonym' eingetragen. Es gibt einen gemeinsamen Preis, einen
+        gemeinsamen Beleg, un N Teilprodukte.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="Anzahl" type="int" maxOccurs="1" minOccurs="1"/>
+      <element name="Tarifprodukt" type="husst:Tarifprodukt_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Preis" type="husst:Preis_Type" maxOccurs="unbounded" minOccurs="0">
+        <annotation>
+          <documentation>
+            Preisinformation zum Produkt, kannauch leer sein
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <element name="Fahrschein" type="husst:ProdFahrschein_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Teilprodukt" type="husst:Produkt_Type" maxOccurs="unbounded" minOccurs="0">
+        <annotation>
+          <documentation>
+            Unterprodukte, die mitverkauftwurden
+            (Teilstrecken,City-Cards,...)
+          </documentation>
+        </annotation>
+      </element>
+      <element name="AnzahlTeile" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Hier werden bei Mehrfahrtenkarten die Anzahl der
+            einzelnen Abschnitte bzw. Anteile notiert. Wenn
+            nicht angegeben ist, ist die Anzahl entweder
+            unbekannt oder als Vorgabe 1.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="RestTeile" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Hier können, je nach Kontext 1.) die Anzahl der derzeitig auf der elektronischen Mehrfahrtenkarte befindlichen "Streifen" oder 2.) die Anzahl der derzeit
+            auf der elektronischen Debitkarte befindlichen Wertanteile notiert werden. Die Betrachtung stellt den Zustand VOR der Aktion dar.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+
+  <complexType name="Pruefabschluss_Type">
+    <sequence>
+      <element name="Ausstieg" type="husst:Transaktionsort_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Ausstiegshaltestelle</documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+    <attribute name="PruefNr" type="int" use="required">
+      <annotation>
+        <documentation></documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Pruefbeginn_Type">
+    <sequence>
+      <element name="Kleidung" type="husst:Pruefkleidung_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Die vom Prüfer getragene Kleidung
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Pruefart" type="husst:Pruefart_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Die Art der Prüfung</documentation>
+        </annotation>
+      </element>
+      <element name="Pruefer" type="string" minOccurs="0" maxOccurs="unbounded">
+        <annotation>
+          <documentation>
+            Beteiligte Prüfer (Nummer)
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Linie" type="int" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Liniennummer</documentation>
+        </annotation>
+      </element>
+      <element name="Verkehrsmittel" type="husst:TransportserviceArt_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Verkehrsmittel</documentation>
+        </annotation>
+      </element>
+      <element name="Einstieg" type="husst:Transaktionsort_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Einstiegshaltestelle</documentation>
+        </annotation>
+      </element>
+      <element name="Richtung" type="husst:Transaktionsort_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>Eine Richtungsangabe</documentation>
+        </annotation>
+      </element>
+      <element name="AnzahlFahrgaeste" type="int" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Eine Abschätzung der Anzahl der Fahrgäste bei Einstieg
+          </documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+    <attribute name="PruefNr" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="Rechnungsstellung_Type">
+    <annotation>
+      <documentation>Dieses Element trägt nähere Angaben zum nachfolgenden Rechnungsstellungs- oder verfolgungsprozess.</documentation>
+    </annotation>
+    <sequence>
+      <element name="RechnungsRef" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            In der Regel eine Rechnungsnummer oder eine generierte Referenz auf eine zu erstellende Rechnung.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="KundenRef" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Eine Referenz auf den Kunden zur Rechnungsstellung, in der Regel eine Kundennummer
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Vorgangszeitpunkt" type="dateTime" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Der zum Verkaufszeitpunkt zugehörige Zeitstempel.</documentation>
+        </annotation>
+      </element>
+      <element name="VorgangsRef" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Ein optionaler Bezug auf den dazugehörigen Verkaufsvorgang.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+
+  <complexType name="Restgeldbeleg_Type">
+    <sequence>
+      <element name="Ausgabevertriebsstelle" type="husst:Vertriebsstelle_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Kennung" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Eine eindeutige Kennung zur Identifikation des Restgeldbelegs.</documentation>
+        </annotation>
+      </element>
+      <element name="Beleg" type="husst:Beleg_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Ausstelldatum" type="dateTime" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Schicht_Type">
+    <sequence>
+      <element name="Datensatz" type="husst:Datensatz_Type" maxOccurs="unbounded" minOccurs="0">
+        <annotation>
+          <documentation>
+            Jede Schicht enthält 2 bis n Datensätze. Für
+            eine
+            ordentliche Schicht sollten mindestens die
+            Datensätze Schichtbeginn
+            und Schichtabschluss
+            enthalten sein.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+    <attribute name="SchichtUID" type="string" use="required">
+      <annotation>
+        <documentation>
+          Diese UID ist eine eindeutiger Wert, der (mit
+          höchster Wahrscheinlichkeit) nur einmalig für alle
+          Geräte zu allen Zeitpunkten an allen Orten existiert.
+          Alle Daten einer Schicht eines Gerätes werden mit
+          dieser ID gekennzeichnet. Die Generierungsvorschrift ist
+          beliebig, solange die obigen Bedingungen eingehalten werden.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="Projekt" type="string" use="optional">
+      <annotation>
+        <documentation>
+          Dies ist eine vom Projektierer vorgegebene
+          Projektkennzeichnung, z.B. "MENT"
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Schichtabschluss_Type">
+    <annotation>
+      <documentation>
+        Der Datensatz zum Schichtabschluss. Dieser Datensatz
+        muss paarweise mit Schichtbeginn vorkommen.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="Ausloeser" type="husst:Ausloeser_Type" minOccurs="1" maxOccurs="1"/>
+      <element name="Beleg" type="husst:Beleg_Type" minOccurs="0" maxOccurs="unbounded"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Schichtbeginn_Type">
+    <annotation>
+      <documentation>
+        Der Datensatz zum Schichtbeginn. Dieser Datensatz muss
+        paarweise mit Schichtabschluss vorkommen.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="SchichtNr" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Diese Schichtnummer enstpricht der den Anwendern
+            bekannte Schichtnummer. In der Regel wird nach
+            dieser Nummer ausgewertet und die Nummer wird
+            auf Belege aufgedruckt. Die Schichtnummer ist
+            mindestens für jede Schicht-UUID eindeutig. Die
+            Schichtnummer sollte inkrementierend aufsteigen
+            und nie '0' sein.
+
+            Achtung: Schichtnummer vs. Dienstnummer:
+            Innerhalb einer Schicht können mehrere Dienste
+            auch gleichzeitig ablaufen. Kein Dienst
+            überlappt zeitlich eine Schichtgrenze. Dienste
+            sind in der Regel Personen-(Konten) oder
+            Geräte-(Konten) zugeordnet. Schichten sind nur
+            ein Behälter für Dienste.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Geraet" type="husst:Geraet_Type" minOccurs="1" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Dieser Datensatz kennzeichnet das technische
+            Gerät, das die Datensätze dieser Schicht
+            erzeugt.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Betriebsart" type="husst:Betriebsart_Type" minOccurs="1" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Dieses Feld unterscheidet die Datensätze dieser
+            Schicht in Echt- und sonstigen Betrieb.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Standort" type="husst:Standort_Type" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Dieses Feld bezeichnet den Standort zum
+            Schichtbeginn.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Schichtenliste_Type">
+    <sequence>
+      <element name="Version" type="husst:VersionStruktur_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Schicht" type="husst:Schicht_Type" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Schichtsummen_Type">
+    <sequence>
+      <element name="Kassenliste" type="husst:Kassenliste_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="BelegKassenliste" type="husst:Belegkassenliste_Type" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Standort_Type">
+    <annotation>
+      <documentation></documentation>
+    </annotation>
+    <sequence>
+      <element name="Typ" type="husst:OrtsTyp_Type" minOccurs="1" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Mit dem Typ wird die Ausprägung des jeweilgen
+            Standorts unterschieden.
+            Die Standorte eines Typs und eines
+            Mandanten sind fortlaufend
+            durchnumeriert.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Name" type="string" minOccurs="0" maxOccurs="1">
+        <annotation>
+          <documentation>
+            Der Name ist ein beliebiger, sprechender Name des
+            Standorts.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
+    <attribute name="Nr" type="int">
+      <annotation>
+        <documentation>
+          Nummer des Nutzungsortes des Gerätes zu dem notierten Zeitpunkt.
+          Die Nummer ist dem jeweiligen Anwender bekannt.
+          Das kann eine Fahrzeugnummer sein, oder ein Kiosknummer,
+          eine Haltestellennummer oder eine Bahnhofsnummer abhängig von den
+          Projektvorgaben und definiert vom jeweiligen Mandanten sein.
+          Die Nummer ist nur zusammen mit der Angabe eines Mandanten eindeutig.
+        </documentation>
+      </annotation>
+    </attribute>
+    <attribute name="Mandant" type="int" use="optional">
+      <annotation>
+        <documentation>
+          Die Standortnummer ist nur zusammen mit einem
+          zugeordneten Mandant eindeutig.
+          Der Standard-Mandant ist '1'.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Stuecke_Type">
+    <sequence>
+      <element name="Anzahl" type="int" maxOccurs="1" minOccurs="1"/>
+      <element name="StueckWert" type="husst:Betrag_Type" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Tarifprodukt_Type">
+    <sequence>
+      <element name="ID_Tarifgebiet" type="husst:INT4" maxOccurs="1" minOccurs="1"/>
+      <element name="ID_Sorte" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+      <element name="ReferenzExternSorte" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Preisstufe" type="husst:INT4" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Die Preisstufe ist nur zusammen mit dem Tarifgebiet gültig.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="ReferenzExternPreisstufe" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Preis" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+      <element name="ReferenzExternPreis" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Preisspalte" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+    <attribute name="DatenversionInhalt" type="string" use="required">
+      <annotation>
+        <documentation>Der Inhalt von "DatenversionInhalt" der Tabelle VersionInhalt der Versorgung</documentation>
+      </annotation>
+    </attribute>
+    <attribute name="DatenversionZeitraum" type="string" use="required">
+      <annotation>
+        <documentation>Als DatenversionZeitraum wird das Feld "DatenversionZeitraum" des zum Verkaufszeitpunkt gültigen Zeitraum-Eintrages mit der höchsten SubZeitraumNr
+          geliefert.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Tarifpunkt_Type">
+    <sequence>
+      <element name="ID_Tarifpunkt" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Tarifgebiet" type="int" maxOccurs="1" minOccurs="1"/>
+      <element name="ReferenzExtern" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Teilrelation_Type">
+    <sequence>
+      <element name="SortOrder" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Die Sortierungsreihenfolge wird benötigt, um die
+            Richtung der Durchfahrt zu erhalten.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="ID_Preisstufe" type="husst:INT4" maxOccurs="1" minOccurs="1"/>
+      <element name="ReferenzExternPreisstufe" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Tarifgebiet" type="husst:INT4" maxOccurs="1" minOccurs="1"/>
+
+      <element name="Start" type="husst:Tarifpunkt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Ziel" type="husst:Tarifpunkt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="ReferenzExternRelation" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Preisquelle" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DatenversionInhalt" type="string" use="required">
+      <annotation>
+        <documentation>Der Inhalt von "DatenversionInhalt" der Tabelle VersionInhalt der Versorgung</documentation>
+      </annotation>
+    </attribute>
+    <attribute name="DatenversionZeitraum" type="string" use="required">
+      <annotation>
+        <documentation>Als DatenversionZeitraum wird das Feld "DatenversionZeitraum" des zum Verkaufszeitpunkt gültigen Zeitraum-Eintrages mit der höchsten SubZeitraumNr
+          geliefert.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Transaktion_Type">
+    <sequence>
+      <element name="Produkt" type="husst:Produkt_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="KundenNr" type="string" maxOccurs="1" minOccurs="0"/>
+      <element name="BezugsNr" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Die BezugsNr enthält bei EBE-Vorgängen die EBE-Kontonummer, bei Gutschein-Vorgängen die Gutscheinnummer, bei Bezahlung bzw. Einlösung von Anteilen vorausbezahlter
+            Anteile auf Karten die Kartennummer.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Vorgangszeitpunkt" type="dateTime" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>
+            Vorgangsnummer und Vorgangszeitpunkt
+            identifizieren einzeln oder gemeinsam einen
+            Vorgang. Im Speziellen werden diese beiden Werte
+            bei der Erstattung eines Gutscheins genutzt,
+            dann entspricht der Vorgangszeitpunkt dem
+            Zeitpunkt der Ausgabe des eingelösten
+            Gutscheins.
+          </documentation>
+        </annotation>
+      </element>
+      <choice>
+        <element name="KAReferenz" type="husst:KAReferenz_Type" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen KA Kontrolldaten enthalten.
+            </documentation>
+          </annotation>
+        </element>
+        <element name="Referenz" type="string" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen Transaktionsdaten als
+              Eindeutigkeitskennzeichen enthalten.
+            </documentation>
+          </annotation>
+        </element>
+      </choice>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="Typ" type="husst:TransaktionTyp_Type" use="required"/>
+    <attribute name="Storno" type="boolean" use="optional" default="false"/>
+  </complexType>
+
+  <complexType name="Transaktionsdaten_Type">
+    <sequence>
+      <element name="Transaktionsart" maxOccurs="1" minOccurs="1" type="husst:Transaktionsart_Type"/>
+      <element name="Transaktionsdaten" type="husst:Any_Type" maxOccurs="1" minOccurs="1"/>
+      <choice>
+        <element name="KAReferenz" type="husst:KAReferenz_Type" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen KA Kontrolldaten enthalten.
+            </documentation>
+          </annotation>
+        </element>
+        <element name="Referenz" type="string" maxOccurs="1" minOccurs="0">
+          <annotation>
+            <documentation>
+              Referenz zu einem global eindeutigen Vorgang
+              - diese Information ist auch in den
+              zugehörigen Kontrolldaten als
+              Eindeutigkeitskennzeichen enthalten.
+            </documentation>
+          </annotation>
+        </element>
+      </choice>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Transaktionsliste_Type">
+    <sequence>
+      <element name="Transaktion" type="husst:Transaktion_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Transaktionsort_Type">
+    <sequence>
+      <element name="Ortspunkt" type="husst:Ortspunkt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Tarifpunkt" type="husst:Tarifpunkt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="ID_Relcode" type="int" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Dieser Inhalt referenziert den Relationscode des Tarifs</documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DatenversionInhalt" type="string" use="required">
+      <annotation>
+        <documentation>Der Inhalt von "DatenversionInhalt" der Tabelle VersionInhalt der Versorgung</documentation>
+      </annotation>
+    </attribute>
+    <attribute name="DatenversionZeitraum" type="string" use="required">
+      <annotation>
+        <documentation>Als DatenversionZeitraum wird das Feld "DatenversionZeitraum" des zum Verkaufszeitpunkt gültigen Zeitraum-Eintrages mit der höchsten SubZeitraumNr
+          geliefert.
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Ueberweisung_Type">
+    <sequence>
+      <element name="BLZ-BIC" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Konto-IBAN" type="string" maxOccurs="1" minOccurs="1"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Verfolgung_Type">
+    <sequence>
+      <element name="Typ" type="husst:VerfolgungsTyp_Type" maxOccurs="unbounded" minOccurs="1"/>
+      <element name="Bemerkung" type="string" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="VersionStruktur_Type">
+    <annotation>
+      <documentation>
+        Hier müssen Hinweise zur Version des Schemas angegeben werden.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="VersionMajor" type="int" maxOccurs="1" minOccurs="1" default="3">
+        <annotation>
+          <documentation>
+            Diese Versionsnummer muss sich immer bei Inkompatibilitäten zur Vorgängerversion ändern.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="VersionMinor" type="int" maxOccurs="1" minOccurs="1" default="6">
+        <annotation>
+          <documentation>
+            Diese Versionsnummer zählt kompatible Anpassungen.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="VersionPatch" type="int" maxOccurs="1" minOccurs="1" default="0">
+        <annotation>
+          <documentation>Diese Versionsnummer zählt abwärtskompatible Bugfixes.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Aenderungsdatum" type="date" maxOccurs="1" minOccurs="1" default="2024-06-28"/>
+      <element name="Aenderungsautor" type="string" maxOccurs="1" minOccurs="1" default="HUSST-Arbeitsgruppe"/>
+    </sequence>
+  </complexType>
+
+
+  <complexType name="Vertriebsstelle_Type">
+    <sequence>
+      <element name="Typ" maxOccurs="1" minOccurs="1" type="husst:OrtsTyp_Type">
+        <annotation>
+          <documentation>
+            Der Typ qualifiziert die beiden Elemente
+            'Mandant' und 'Nr'.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Mandant" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Der Mandant qualifiziert eindeutig die
+            Zugehörigkeit der 'Nr'.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="Nr" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Hier wird, je nach Typ der Vertriebsstelle, die
+            Personalnummer, die Vertriebsstellennummer, die
+            Gerätenummer etc. hinterlegt. Die Nummer ist nur
+            in Beziehung zu Mandant und dem Typ eindeutig.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Warenkorb_Type">
+    <sequence>
+      <element name="ReferenzExtern" type="string" maxOccurs="1" minOccurs="0">
+        <annotation>
+          <documentation>Definiert optional einen Identifier, um den Warenkorb eindeutig zu referenzieren.</documentation>
+        </annotation>
+      </element>
+      <element name="Transaktionsort" type="husst:Transaktionsort_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Transaktionliste" type="husst:Transaktionsliste_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Zahlungsliste" type="husst:Zahlungsliste_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="DienstNr" type="int" use="required"/>
+  </complexType>
+
+  <complexType name="Wertbehaelter_Type">
+    <annotation>
+      <documentation>
+        Hiermit werden Wertbehälter erfasst, z.B. Safebags.
+        Die Nummer enstpricht der Nummer des Wertbehälters, die Wertanzahl
+        der Anzahl der werthaltigen Anteile, z.B. die Anzahl der Belege.
+
+        Es werden 2 Behälter unterschieden:
+        1. Behälter mit Bargeld -> dann muss der Betrag ausgefüllt sein (früher Wert),
+        2. Behälter mit werthaltigen Belegen -> dann muss die Wertanzahl ausgefüllt sein.
+        3. Eine Mischform ist auch möglich.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name="WertAnzahl" type="int" maxOccurs="1" minOccurs="0"/>
+      <element name="Betrag" type="husst:Betrag_Type" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+    <attribute name="Kennung" type="string" use="required"/>
+  </complexType>
+
+  <complexType name="Zaehldaten_Type">
+    <sequence>
+      <element name="Einsteiger" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+      <element name="Aussteiger" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+      <element name="Fehler" type="husst:INT4" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+    <attribute name="Kennung" type="int" use="required">
+      <annotation>
+        <documentation>
+          Die spezielle Bezeichnung dieser Zähldatneinheit
+        </documentation>
+      </annotation>
+    </attribute>
+  </complexType>
+
+  <complexType name="Zaehldatenliste_Type">
+    <sequence>
+      <element name="Zaehldaten" type="husst:Zaehldaten_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Zahlung_Type">
+    <sequence>
+      <element name="Betrag" type="husst:Betrag_Type" maxOccurs="1" minOccurs="1"/>
+      <element name="Zahlart" type="husst:BezahlArt_Type" maxOccurs="1" minOccurs="1"/>
+      <choice>
+        <element name="Barbezahlung" type="husst:Barbezahlung_Type" maxOccurs="1" minOccurs="1"/>
+        <element name="Gutschein" type="husst:Gutscheinbezahlung_Type" maxOccurs="1" minOccurs="1">
+          <annotation>
+            <documentation>
+              Obsolet: Gutscheine, bei Zahlungsart
+              Gutschein, diese Art der Verrechnung per
+              Gutschein sollte nicht mehr genutzt werden.
+            </documentation>
+          </annotation>
+        </element>
+        <element name="ZVTBezahlung" type="husst:ZVTBezahlung_Type" maxOccurs="1" minOccurs="1"/>
+        <element name="KABezahlungReferenz" type="husst:KAReferenz_Type" maxOccurs="1" minOccurs="1"/>
+        <element name="Lastschrift" type="husst:Lastschrift_Type" maxOccurs="1" minOccurs="1"/>
+        <element name="Ueberweisung_Type" type="husst:Ueberweisung_Type" maxOccurs="1" minOccurs="1"/>
+        <element name="KKOfflineBezahlung" type="husst:KKOfflineBezahlung_Type" maxOccurs="1" minOccurs="1"/>
+        <element name="Restgeldbeleg" type="husst:Restgeldbeleg_Type" maxOccurs="1" minOccurs="1"/>
+        <element name="Rechnungsstellung" type="husst:Rechnungsstellung_Type" maxOccurs="1" minOccurs="1"/>
+        <element name="WebShopBezahlung" type="husst:WebShopBezahlung_Type" maxOccurs="1" minOccurs="1"/>
+      </choice>
+      <element name="Beleg" type="husst:Beleg_Type" maxOccurs="unbounded" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="Zahlungsliste_Type">
+    <sequence>
+      <element name="Zahlung" type="husst:Zahlung_Type" minOccurs="0" maxOccurs="unbounded"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="ZVTBezahlung_Type">
+    <sequence>
+      <element name="Kartenherausgeber" type="husst:BezahlArt_Type" maxOccurs="1" minOccurs="0"/>
+      <element name="TerminalId" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="TransaktionsNr" type="string" maxOccurs="1" minOccurs="1"/>
+      <element name="Zeitpunkt" type="dateTime" maxOccurs="1" minOccurs="0"/>
+    </sequence>
+  </complexType>
+
+  <complexType name="WebShopBezahlung_Type">
+    <sequence>
+      <element name="TerminalId" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>Eindeutige Terminal-ID bei Verwendung eines gesonderten Kartenzahlungsterminals.</documentation>
+        </annotation>
+      </element>
+      <element name="TransaktionsNr" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>Vom Zahlungsdienstleister vergebene, eindeutige Transaktionsnummer der durchgeführten Zahlungstransaktion.</documentation>
+        </annotation>
+      </element>
+      <element name="Zeitpunkt" type="dateTime" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>Zeitpunkt, zu dem die Zahlungstransaktion beim Zahlungsdienstleister registriert wurde.</documentation>
+        </annotation>
+      </element>
+    </sequence>
+  </complexType>
+
+
+  <simpleType name="Betriebszeit_Type">
+    <annotation>
+      <documentation>
+        Betriebszeiten dürfen über 24:00 Uhr hinausgehen
+      </documentation>
+    </annotation>
+    <restriction base="string">
+      <pattern value="[0-9]{1,2}:[0-9]{1,2}"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="blobString">
+    <restriction base="string">
+      <pattern value="[ -þ€–]*"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Char">
+    <restriction base="string">
+      <minLength value="1"/>
+      <maxLength value="1"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Codierung_Type">
+    <annotation>
+      <documentation>
+        Die Codierung entspricht der DB-Codierung
+      </documentation>
+    </annotation>
+    <restriction base="string">
+      <pattern value="[1-9a-zA-Z]{2}"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="DateCompact">
+    <restriction base="date">
+      <minInclusive value="1990-01-01"/>
+      <maxInclusive value="2117-12-31"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="DateTimeCompact">
+    <restriction base="dateTime">
+      <minInclusive value="1990-01-01T00:00:00Z"/>
+      <maxInclusive value="2117-12-31T23:59:58Z"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="FLOAT1">
+    <annotation>
+      <documentation>
+        englische Notation beachten, z. B. 19 Euro = 19.00 Euro
+      </documentation>
+    </annotation>
+    <restriction base="decimal">
+      <minInclusive value="0"/>
+      <maxInclusive value="100"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="INT1">
+    <restriction base="unsignedInt">
+      <minInclusive value="0"/>
+      <maxInclusive value="255"/>
+    </restriction>
+  </simpleType>
+  <simpleType name="INT2">
+    <restriction base="unsignedInt">
+      <minInclusive value="0"/>
+      <maxInclusive value="65535"/>
+    </restriction>
+  </simpleType>
+  <simpleType name="INT3">
+    <restriction base="unsignedInt">
+      <minInclusive value="0"/>
+      <maxInclusive value="16777215"/>
+    </restriction>
+  </simpleType>
+  <simpleType name="INT4">
+    <restriction base="unsignedInt">
+      <minInclusive value="0"/>
+      <maxInclusive value="4294967295"/>
+    </restriction>
+  </simpleType>
+  <simpleType name="INT8">
+    <restriction base="unsignedLong">
+      <minInclusive value="0"/>
+      <maxInclusive value="18446744073709551615"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="KoordWgs84_Type">
+    <restriction base="float"/>
+  </simpleType>
+
+  <simpleType name="Waehrung_Type">
+    <annotation>
+      <documentation>Währungscode nach ISO 4217.</documentation>
+    </annotation>
+    <restriction base="string">
+      <pattern value="[A-Z]{3}"/>
+    </restriction>
+  </simpleType>
+
+
+  <simpleType name="Projektspezifisch_Type">
+    <annotation>
+      <documentation>Erlaubt alle Werte, die nicht mit "husst." beginnen.</documentation>
+    </annotation>
+    <restriction base="string">
+      <pattern value="((h[^u])|hu[^s]|hus[^s]|huss[^t]|husst[^\.]|[a-gi-zA-ZöäüÖÄÜß][a-zA-ZöäüÖÄÜß0-9]*)([\-\.][a-zA-ZöäüÖÄÜß0-9]+)*"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="ProjektspezifischAnstattKa_Type">
+    <annotation>
+      <documentation>
+        Definiert einen Typ, der anstatt eines Wertes aus der KA-Enumeration genutzt werden kann.
+        Die KA-Enumerationen definieren Werte zwischen 1 und 255 (INT1). Wenn Buchstaben vorkommen, ist es ein Projektspezifischer Wert.
+      </documentation>
+    </annotation>
+    <restriction base="string">
+      <pattern value="[A-Za-z][A-Za-z0-9_]*"/>
+    </restriction>
+  </simpleType>
+
+
+  <simpleType name="AusgabeabschnittTyp_Type">
+    <annotation>
+      <documentation>Beschreibt den Typ eines ausgegebenen Papierdokumentes näher.</documentation>
+    </annotation>
+    <union memberTypes="husst:AusgabeabschnittTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="AusgabeabschnittTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Fahrschein"/>
+      <enumeration value="husst.Rollenbeginn"/>
+      <enumeration value="husst.Rollenende"/>
+      <enumeration value="husst.Probedruck"/>
+      <enumeration value="husst.Quittung"/>
+      <enumeration value="husst.Beleg"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Ausloeser_Type">
+    <annotation>
+      <documentation></documentation>
+    </annotation>
+    <union memberTypes="husst:AusloeserHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="AusloeserHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.manuell"/>
+      <enumeration value="husst.automatisch"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="BelegkasseTyp_Type">
+    <annotation>
+      <documentation></documentation>
+    </annotation>
+    <union memberTypes="husst:BelegkasseTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="BelegkasseTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Restgeldquittung"/>
+      <enumeration value="husst.Stornierung"/>
+      <enumeration value="husst.Gutschein"/>
+      <enumeration value="husst.Ruecknahme"/>
+      <enumeration value="husst.Chipkarte"/>
+      <enumeration value="husst.Flugcoupon"/>
+      <enumeration value="husst.Anfahrtscoupon"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="BelegTyp_Type">
+    <annotation>
+      <documentation></documentation>
+    </annotation>
+    <union memberTypes="husst:BelegTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="BelegTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Papier"/>
+      <enumeration value="husst.ECard"/>
+      <enumeration value="husst.KACard"/>
+      <enumeration value="husst.BOBCard"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Betriebsart_Type">
+    <union memberTypes="husst:BetriebsartHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="BetriebsartHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Echtbetrieb"/>
+      <enumeration value="husst.Testbetrieb"/>
+      <enumeration value="husst.Schulungsbetrieb"/>
+    </restriction>
+  </simpleType>
+
+  <complexType name="BezahlArt_Type">
+    <simpleContent>
+      <extension base="husst:BezahlArtSimple_Type">
+        <attribute name="Bezeichnung" type="string" use="optional">
+          <annotation>
+            <documentation>
+              Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
+            </documentation>
+          </annotation>
+        </attribute>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <simpleType name="BezahlArtSimple_Type">
+    <union memberTypes="husst:BezahlArtKa_Type husst:ProjektspezifischAnstattKa_Type"/>
+  </simpleType>
+  <simpleType name="BezahlArtKa_Type">
+    <annotation>
+      <documentation>
+        Die BezahlArt kommt aus der VDV-KA.
+        Die KA-Werte kommen aus dem EN1545: PaymentMeansCode
+      </documentation>
+    </annotation>
+    <restriction base="husst:INT1">
+      <enumeration value="0">
+        <annotation>
+          <documentation>Keine Angabe</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="1">
+        <annotation>
+          <documentation>Bar</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="3">
+        <annotation>
+          <documentation>Kreditkarte</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="5">
+        <annotation>
+          <documentation>POB/PEB</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="6">
+        <annotation>
+          <documentation>EC-Karte/Lastschrift</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="7">
+        <annotation>
+          <documentation>Rechnung</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="8">
+        <annotation>
+          <documentation>Werteinheiten</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="14">
+        <annotation>
+          <documentation>Gutschein/Voucher</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="17">
+        <annotation>
+          <documentation>ec-Cash</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="24">
+        <annotation>
+          <documentation>Geldkarte</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="25">
+        <annotation>
+          <documentation>Mastercard</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="26">
+        <annotation>
+          <documentation>Visacard</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="27">
+        <annotation>
+          <documentation>HandyTicket Konto</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="28">
+        <annotation>
+          <documentation>Mobilfunkrechnung</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="100">
+        <annotation>
+          <documentation>Amazon Pay</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="101">
+        <annotation>
+          <documentation>Amex</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="102">
+        <annotation>
+          <documentation>Android Pay</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="103">
+        <annotation>
+          <documentation>Apple-Pay</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="104">
+        <annotation>
+          <documentation>(Sonstige) Appbasierte Zahlverfahren</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="105">
+        <annotation>
+          <documentation>Girocard kontaktlos</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="106">
+        <annotation>
+          <documentation>Girogo (GeldKarte kontaktlos)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="107">
+        <annotation>
+          <documentation>Giropay</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="108">
+        <annotation>
+          <documentation>Maestro</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="109">
+        <annotation>
+          <documentation>Mastercard paypass (kontaktlos)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="110">
+        <annotation>
+          <documentation>Paydirekt</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="111">
+        <annotation>
+          <documentation>PayPal</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="112">
+        <annotation>
+          <documentation>PrintTicket-Konto</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="113">
+        <annotation>
+          <documentation>Sofortüberweisung</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="114">
+        <annotation>
+          <documentation>V-Pay</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="115">
+        <annotation>
+          <documentation>VISA paywave (kontaktlos)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="116">
+        <annotation>
+          <documentation>(Sonstige) Web-basierte Zahlverfahren</documentation>
+        </annotation>
+      </enumeration>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="GeldbehaelterTyp_Type">
+    <union memberTypes="husst:GeldbehaelterTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="GeldbehaelterTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Personenkasse"/>
+      <enumeration value="husst.Muenzendkasse"/>
+      <enumeration value="husst.Banknotenendkasse"/>
+      <enumeration value="husst.Geldwechsler"/>
+      <enumeration value="husst.Geldspeicher"/>
+      <enumeration value="husst.Zwischenkasse"/>
+      <enumeration value="husst.Wertbehaelter"/>
+      <enumeration value="husst.Handkasse"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="GeldBehaeltervorgang_Type">
+    <annotation>
+      <documentation>
+        Übergabemeldung dient zur Registrierung von Safebag-Nummern.
+      </documentation>
+    </annotation>
+    <union memberTypes="husst:GeldBehaeltervorgangHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="GeldBehaeltervorgangHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Anfangsbestand"/>
+      <enumeration value="husst.Endbestand"/>
+      <enumeration value="husst.Behaelterzufuehrung"/>
+      <enumeration value="husst.Behaelterentnahme"/>
+      <enumeration value="husst.Bestandsaufnahme"/>
+      <enumeration value="husst.Befuellung"/>
+      <enumeration value="husst.Entnahme"/>
+      <enumeration value="husst.Uebergabemeldung"/>
+      <enumeration value="husst.Entnahmemeldung"/>
+      <enumeration value="husst.Geldabwurf"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="KasseTyp_Type">
+    <annotation>
+      <documentation></documentation>
+    </annotation>
+    <union memberTypes="husst:KasseTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="KasseTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.bar"/>
+      <enumeration value="husst.unbar"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="KomponentenKlasse_Type">
+    <union memberTypes="husst:KomponentenKlasseHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="KomponentenKlasseHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Software"/>
+      <enumeration value="husst.Hardware"/>
+      <enumeration value="husst.Daten"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="KomponentenVorgang_Type">
+    <union memberTypes="husst:KomponentenVorgangHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="KomponentenVorgangHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Entnahme"/>
+      <enumeration value="husst.Zufuehrung"/>
+      <enumeration value="husst.Bestandsaufnahme"/>
+      <enumeration value="husst.Update"/>
+    </restriction>
+  </simpleType>
+
+  <complexType name="KundenTyp_Type">
+    <simpleContent>
+      <extension base="husst:KundenTypSimple_Type">
+        <attribute name="Bezeichnung" type="string" use="optional">
+          <annotation>
+            <documentation>
+              Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
+            </documentation>
+          </annotation>
+        </attribute>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <simpleType name="KundenTypSimple_Type">
+    <union memberTypes="husst:KundenTypKa_Type husst:ProjektspezifischAnstattKa_Type"/>
+  </simpleType>
+  <simpleType name="KundenTypKa_Type">
+    <annotation>
+      <documentation>
+        Der Kundentyp kommt aus der VDV-KA.
+        Die KA-Werte kommen aus dem EN1545: ProfileCodeIOP
+      </documentation>
+    </annotation>
+    <restriction base="husst:INT1">
+      <enumeration value="0">
+        <annotation>
+          <documentation>nicht spezifiziert/unbestimmt</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="1">
+        <annotation>
+          <documentation>Erwachsener</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="2">
+        <annotation>
+          <documentation>Kind</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="3">
+        <annotation>
+          <documentation>Student</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="5">
+        <annotation>
+          <documentation>Behinderter</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="6">
+        <annotation>
+          <documentation>Sehbehinderter</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="7">
+        <annotation>
+          <documentation>Hoergeschaedigter</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="8">
+        <annotation>
+          <documentation>Arbeitsloser/Sozialhilfeempfaenger</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="9">
+        <annotation>
+          <documentation>Personal</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="10">
+        <annotation>
+          <documentation>Militaeranhehoeriger</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="19">
+        <annotation>
+          <documentation>Schueler</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="20">
+        <annotation>
+          <documentation>Azubi</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="25">
+        <annotation>
+          <documentation>Senior</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="64">
+        <annotation>
+          <documentation>ermäßigt</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="65">
+        <annotation>
+          <documentation>Fahrrad</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="66">
+        <annotation>
+          <documentation>Hund</documentation>
+        </annotation>
+      </enumeration>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Meldungsklasse_Type">
+    <union memberTypes="husst:MeldungsklasseHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="MeldungsklasseHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Debug"/>
+      <enumeration value="husst.Info"/>
+      <enumeration value="husst.Warnung"/>
+      <enumeration value="husst.Fehler"/>
+      <enumeration value="husst.SchwererFehler"/>
+    </restriction>
+  </simpleType>
+
+  <complexType name="OrtsTyp_Type">
+    <simpleContent>
+      <extension base="husst:OrtsTypSimple_Type">
+        <attribute name="Bezeichnung" type="string" use="optional">
+          <annotation>
+            <documentation>
+              Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
+            </documentation>
+          </annotation>
+        </attribute>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <simpleType name="OrtsTypSimple_Type">
+    <union memberTypes="husst:OrtsTypKa_Type husst:ProjektspezifischAnstattKa_Type"/>
+  </simpleType>
+  <simpleType name="OrtsTypKa_Type">
+    <annotation>
+      <documentation>
+        Der OrtsTyp kommt aus der VDV-KA.
+        Die KA-Werte kommen aus dem EN1545: LocationTypeCode
+      </documentation>
+    </annotation>
+    <restriction base="husst:INT1">
+      <enumeration value="0">
+        <annotation>
+          <documentation>Bushaltestelle</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="1">
+        <annotation>
+          <documentation>U-Bahn- (Metro-)Station</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="2">
+        <annotation>
+          <documentation>Bahnhof (Eisenbahn)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="3">
+        <annotation>
+          <documentation>Strassenbahn- (TRAM-) Haltestelle</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="11">
+        <annotation>
+          <documentation>Verkaufsstelle</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="16">
+        <annotation>
+          <documentation>Gebiet(auch fuer Zone)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="17">
+        <annotation>
+          <documentation>Korridor</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="200">
+        <annotation>
+          <documentation>
+            Haltestelle allgemein
+            fuer Haltestellen im Fahrplansinne,
+            unabhaengig vom Verkehrsmittel
+          </documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="201">
+        <annotation>
+          <documentation>Massenpersonalisierer</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="202">
+        <annotation>
+          <documentation>areaList_ID</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="203">
+        <annotation>
+          <documentation>im Fahrzeug/Zug</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="204">
+        <annotation>
+          <documentation>TouchPoint</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="205">
+        <annotation>
+          <documentation>im Fahrzeug der Linie</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="206">
+        <annotation>
+          <documentation>im Fahrzeug der Zugnummer</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="207">
+        <annotation>
+          <documentation>Teilzone</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="208">
+        <annotation>
+          <documentation>neutrale Zone</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="209">
+        <annotation>
+          <documentation>Wabe</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="210">
+        <annotation>
+          <documentation>Grosswabe</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="211">
+        <annotation>
+          <documentation>Tarifpunkt</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="212">
+        <annotation>
+          <documentation>Backoffice</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="213">
+        <annotation>
+          <documentation>im Fahrzeug an Haltestelle</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="214">
+        <annotation>
+          <documentation>Ereignisort (event location)</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="215">
+        <annotation>
+          <documentation>Ticketserver</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="251">
+        <annotation>
+          <documentation>Ortsteil</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="252">
+        <annotation>
+          <documentation>Gemeinde</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="253">
+        <annotation>
+          <documentation>Kreis</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="254">
+        <annotation>
+          <documentation>Land</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="255">
+        <annotation>
+          <documentation>keine Angabe</documentation>
+        </annotation>
+      </enumeration>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Preisverrechnung_Type">
+    <union memberTypes="husst:PreisverrechnungHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="PreisverrechnungHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Basispreis"/>
+      <enumeration value="husst.Abschlag"/>
+      <enumeration value="husst.Zuschlag"/>
+      <enumeration value="husst.Information"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Pruefart_Type">
+    <union memberTypes="husst:PruefartHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="PruefartHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Standardpruefung"/>
+      <enumeration value="husst.Abgangskontrolle"/>
+      <enumeration value="husst.Sonstiges"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Pruefkleidung_Type">
+    <union memberTypes="husst:PruefkleidungHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="PruefkleidungHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Zivilkleidung"/>
+      <enumeration value="husst.Dienstkleidung"/>
+      <enumeration value="husst.Sonstiges"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="Transaktionsart_Type">
+    <union memberTypes="husst:TransaktionsartHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="TransaktionsartHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.KA"/>
+      <enumeration value="husst.Geldkarte"/>
+      <enumeration value="husst.BOB"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="TransaktionTyp_Type">
+    <union memberTypes="husst:TransaktionTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="TransaktionTypHUSST_Type">
+    <annotation>
+      <documentation>Sonderfälle:
+        • Gutscheine werden verkauft
+        • Gutscheine werden erstattet
+
+        • EBE-Einzahlung – der Kunde „kauft“ aus seiner EBE-Schuld mit der „BezugsNr“ einen Anteil, es liegt ein ktTransTyp „husst.Verkauf“ vor.
+        Es gibt einen Preis, es wird ein Beleg gedruckt.
+
+        • Die Ausgabe eines Wertes auf eine Karte (Debitkarte) entspricht dem Verkauf eines Gutscheins. Der Unterschied zum Gutschein ist,
+        dass dieser Gutschein in Tranchen eingelöst werden kann. Es muss auf alle Fälle die „BezugsNr“ (sprich Kartennummer)
+        und je nach Anwendung die Kundennummer beim Verkauf notiert werden.
+        • Die Einlösung eines Wertes entspricht der teilweisen oder vollständigen Erstattung eines Gutscheins mit den gleichen Registrierungen,
+        es können jedoch auch nur Teilwerte „erstattet“ werden. (ktTransTyp = husst.Erstattung)
+
+        • Der Verkauf einer elektronischen Mehrfahrtenkarte entspricht dem Verkauf einer Mehrfahrtenkarte auf Papier mit dem einzigen Unterschied,
+        dass die BezugsNr (sprich Kartennummer) und je nach Anwendung die Kundennummer registriert wird. In dem Feld „AnzahlTeile“ kann
+        die Menge der Mehrfahrten, die jedoch schon über die Sorte festgelegt sein sollten, zusätzlich notiert werden.
+        • Das Entwerten eines oder mehrerer „Streifen“ einer elektronischen Mehrfahrtenkarte kann mittels „Registrierung“ erfasst werden.
+        Wieder unterscheidet die Tarifprodukt den Kontext, es gibt keinen Preis, nur eventuell einen Beleg, aber eine „BezugsNr“.
+        In dem Feld „AnzahlTeile“ müssen die Menge der entwerteten „Streifen“ notiert werden.
+      </documentation>
+    </annotation>
+    <restriction base="string">
+      <enumeration value="husst.Verkauf"/>
+      <enumeration value="husst.Erstattung"/>
+      <enumeration value="husst.Registrierung"/>
+      <enumeration value="husst.Einzahlung"/>
+    </restriction>
+  </simpleType>
+
+  <complexType name="TransportserviceArt_Type">
+    <simpleContent>
+      <extension base="husst:TransportserviceArtSimple_Type">
+        <attribute name="Bezeichnung" type="string" use="optional">
+          <annotation>
+            <documentation>
+              Die Angabe der Bezeichnung ist optional und dient nur der Leserlichkeit
+            </documentation>
+          </annotation>
+        </attribute>
+      </extension>
+    </simpleContent>
+  </complexType>
+  <simpleType name="TransportserviceArtSimple_Type">
+    <union memberTypes="husst:TransportserviceArtKa_Type husst:ProjektspezifischAnstattKa_Type"/>
+  </simpleType>
+  <simpleType name="TransportserviceArtKa_Type">
+    <annotation>
+      <documentation>
+        Die TransportserviceArt kommt aus der VDV-KA.
+        Die KA-Werte kommen aus dem EN1545: TransportTypeCode
+      </documentation>
+    </annotation>
+    <restriction base="husst:INT1">
+      <enumeration value="0">
+        <annotation>
+          <documentation>nicht spezifiziert/unbestimmt</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="1">
+        <annotation>
+          <documentation>Linienbus im Stadtverkehr</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="3">
+        <annotation>
+          <documentation>Metro/U-Bahn/S-Bahn</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="4">
+        <annotation>
+          <documentation>Strassenbahn/TRAM</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="6">
+        <annotation>
+          <documentation>Schiff</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="10">
+        <annotation>
+          <documentation>ICE</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="11">
+        <annotation>
+          <documentation>Überlandbus/Regionalbus</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="19">
+        <annotation>
+          <documentation>Regionalzug</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="20">
+        <annotation>
+          <documentation>IC</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="21">
+        <annotation>
+          <documentation>Standseilbahn</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="29">
+        <annotation>
+          <documentation>Regionalexpress</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="30">
+        <annotation>
+          <documentation>Expressbus</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="31">
+        <annotation>
+          <documentation>Flughafenzubringer</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="32">
+        <annotation>
+          <documentation>Verbundnahverkehr</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="33">
+        <annotation>
+          <documentation>Verbundnahverkehr ohne Kurzstrecke</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="34">
+        <annotation>
+          <documentation>SPNV</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="35">
+        <annotation>
+          <documentation>Verbundnahverkehr ohne Sonderverkehrsmittel</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="36">
+        <annotation>
+          <documentation>Fähre</documentation>
+        </annotation>
+      </enumeration>
+      <enumeration value="37">
+        <annotation>
+          <documentation>Bergbahn</documentation>
+        </annotation>
+      </enumeration>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="VerfolgungsTyp_Type">
+    <union memberTypes="husst:VerfolgungsTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="VerfolgungsTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.Polizei"/>
+      <enumeration value="husst.Anonym"/>
+      <enumeration value="husst.AnnahmeVerweigert"/>
+      <enumeration value="husst.VerkaufsDefekt"/>
+      <enumeration value="husst.Umsteiger"/>
+      <enumeration value="husst.Nacherfassung"/>
+      <enumeration value="husst.Loeschung"/>
+      <enumeration value="husst.Kulanz"/>
+    </restriction>
+  </simpleType>
+
+  <simpleType name="VorgangsTyp_Type">
+    <union memberTypes="husst:VorgangsTypHUSST_Type husst:Projektspezifisch_Type"/>
+  </simpleType>
+  <simpleType name="VorgangsTypHUSST_Type">
+    <restriction base="string">
+      <enumeration value="husst.KeinFS"/>
+      <enumeration value="husst.UngueltigerFS"/>
+      <enumeration value="husst.TeilungueltigerFS"/>
+      <enumeration value="husst.Betrugsversuch"/>
+      <enumeration value="husst.Alkohol"/>
+      <enumeration value="husst.Rauchen"/>
+      <enumeration value="husst.Sachbeschaedigung"/>
+      <enumeration value="husst.Verhalten"/>
+      <enumeration value="husst.Notbremse"/>
+      <enumeration value="husst.Sonstiges"/>
+    </restriction>
+  </simpleType>
+
+  <element name="Schichten" type="husst:Schichtenliste_Type"/>
+</schema>

--- a/Version 3/README.md
+++ b/Version 3/README.md
@@ -18,11 +18,11 @@ Weitere Hersteller können sich gerne einen Bereich via Pullrequest oder Issue a
 ## Changelog
 
 ### 3.7.0 -> 3.8.0
-Änderungsdatum: 16. Juni 2025
+Änderungsdatum: 17. Juli 2025
 Matching von Verbund- und Streckenverbindungen 
 * DvTarifAngebot
-   * Ergänzung StreckencodeVerlauf_Type 
-   * Relationen_Type ergänzt um ID_StreckencodeVerlauf (optional)
+   * Ergänzung Streckenverlauf_Type 
+   * Relationen_Type ergänzt um ID_Streckenverlauf (optional)
 
 ### 3.6.0 -> 3.7.0
 Änderungsdatum: 15. Januar 2025

--- a/Version 3/README.md
+++ b/Version 3/README.md
@@ -17,6 +17,13 @@ Weitere Hersteller können sich gerne einen Bereich via Pullrequest oder Issue a
 
 ## Changelog
 
+### 3.7.0 -> 3.8.0
+Änderungsdatum: 16. Juni 2025
+Matching von Verbund- und Streckenverbindungen 
+* DvTarifAngebot
+   * Ergänzung StreckencodeVerlauf_Type 
+   * Relationen_Type ergänzt um ID_StreckencodeVerlauf (optional)
+
 ### 3.6.0 -> 3.7.0
 Änderungsdatum: 15. Januar 2025
 Parallele Suche in Verbund- und Streckentarifen ermöglichen / unterbinden


### PR DESCRIPTION
Hier einmal der PR für die neue Version 3.8.0, welche das heute besprochene Konzept für das Via-Matching beinhaltet.

@horst-p-w-neubauer ich habe die extra DS ID bei dem streckenbasierten Entwurf jetzt mal weggelassen, da man nicht zwei mal die gleiche Strecke durchfahren darf.