### PR TITLE
ReferenzTransaktion_Type definiert und zu Transaktion hinzugefügt

### DIFF
--- a/Version 3/3.8.0/HUSST_Ergebnisdaten_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_Ergebnisdaten_3_8_0.xsd
@@ -1454,11 +1454,47 @@
             </documentation>
           </annotation>
         </element>
+        <element name="ReferenzTransaktion" type="husst:ReferenzTransaktion_Type" maxOccurs="1" minOccurs="0">
+          <annotation>
+          <documentation>
+            Das Element ReferenzTransaktion kann genutzt werden, um eindeutig auf eine andere Transaktion zu zeigen.
+            So kann beispielsweise eine Storno-Transaktion auf die Verkaufs-Transaktion zeigen, die storniert wurde.
+          </documentation>
+        </annotation>
+        </element>
       </choice>
       <element name="DynAttribut" type="husst:DynAttribut_Subtype" maxOccurs="unbounded" minOccurs="0"/>
     </sequence>
     <attribute name="Typ" type="husst:TransaktionTyp_Type" use="required"/>
     <attribute name="Storno" type="boolean" use="optional" default="false"/>
+  </complexType>
+
+  <complexType name="ReferenzTransaktion_Type">
+    <sequence>
+      <element name="SchichtUID" type="string" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Die SchichtUID identifiziert die Schicht, in der das referenzierte Produkt enthalten ist.
+            Dies kann beispielsweise relevant sein, wenn eine Stornierung nachträglich im Hintergrundsystem 
+            oder an einem anderen Gerät erfolgt ist.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="WarenkorbBelegNr" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Die WarenkorbBelegNr identifiziert den Warenkorb, auf den referenziert wird.
+          </documentation>
+        </annotation>
+      </element>
+      <element name="ProduktBelegNr" type="int" maxOccurs="1" minOccurs="1">
+        <annotation>
+          <documentation>
+            Die ProduktBelegNr identifiziert das Produkt, auf das referenziert wird.
+          </documentation>
+        </annotation>
+      </element>
+    </sequence>
   </complexType>
 
   <complexType name="Transaktionsdaten_Type">

--- a/Version 3/3.8.0/HUSST_Ergebnisdaten_3_8_0.xsd
+++ b/Version 3/3.8.0/HUSST_Ergebnisdaten_3_8_0.xsd
@@ -1271,6 +1271,7 @@
     <sequence>
       <element name="Version" type="husst:VersionStruktur_Type" maxOccurs="1" minOccurs="1"/>
       <element name="Schicht" type="husst:Schicht_Type" maxOccurs="unbounded" minOccurs="0"/>
+      <any namespace="http://www.w3.org/2000/09/xmldsig#" minOccurs="0" maxOccurs="1" processContents="lax"/>
     </sequence>
   </complexType>
 


### PR DESCRIPTION
### Inhalt des Pull Requests

Dieser Pull Request fügt dem `Transaktion_Type` ein neues Element hinzu, das die Referenzierung einer Transaktion auf eine andere ermöglicht.

**Info:** Ich habe den Pull Request bewusst gegen 3.8.0 geöffnet, damit das Diff besser zu erkennen ist. Ist alles abgeklärt, werde ich die Minor-Version hochzählen und das Changelog erstellen.

**HUSST-Datei Signierung**
Es wurde ein Element zum Schichtenliste_Type-Element hinzugefügt, was für die Signierung der HUSST-Dateien erforderlich ist.


---

### Problemstellung

Bei einem Storno wird ein fest definierter Verkaufsdatensatz rückgängig gemacht (anders als bei einer Erstattung). Aktuell ist es über HUSST jedoch nicht möglich, eine direkte Referenz vom Storno auf den ursprünglichen Verkaufsdatensatz herzustellen bzw. nur über nicht weiter definierte Umwege. Eine solche Referenz ist jedoch in Folgeprozessen wie Einnahmemeldungen erforderlich, da hier eine eindeutige 1:1-Beziehung zwischen den beiden Datensätzen bestehen muss.

Derzeit umgehen wir dieses Problem, indem wir die `BezugNr` mit der `BelegNr` des stornierten Produkts füllen. Das funktioniert in vielen Fällen, jedoch nicht immer. In manchen Fällen wird die `Warenkorb`-`BelegNr` pro Schicht und die `Produkt`-`BelegNr` pro Warenkorb hochgezählt. Daher reicht ein einzelnes Feld zur eindeutigen Identifikation nicht aus. Die Nummern sind also nur in Kombination mit der Schicht- und Warenkorbnummer eindeutig.

Hinzu kommt, dass laut XSD-Dokumentation das bestehende Feld  für andere Informationen vorgesehen ist. Das führt zu inhaltlichen Konflikten bei der Verwendung desselben Feldes für unterschiedliche Zwecke. Außerdem lässt es Interpretationsspielraum für die Befüllung zu, da nichts weiter dokumentiert ist.

---

### Lösung AMCON

Zur eindeutigen Referenzierung wurde das neue optionale Element `ReferenzTransaktion_Type` eingeführt. Dieser Typ enthält drei Felder:

- `SchichtUID`
- `WarenkorbBelegNr`
- `ProduktBelegNr`
    
Damit kann eine Transaktion eindeutig referenziert werden. Die `SchichtUID` ermöglicht auch die Zuordnung zu Datensätzen aus anderen Schichten, z. B. bei nachträglichen Stornos von Verkäufen aus dem Hintergrundsystemen.

Innerhalb einer Schicht sind mindestens die `WarenkorbBelegNr` und die `ProduktBelegNr` erforderlich, um die Referenz herzustellen.


---

### Bereits evaluierte Alternativen

#### 1. Verwendung eines DynAttributes

Eine mögliche Lösung wäre die Nutzung eines dynamischen Attributs. Diese Lösung wäre technisch machbar, allerdings möchten wir (AMCON) gerne einen allgemein gültigen Mechanismus für Referenzierungen etablieren. Derzeit wird eine projektübergreifende Importschnittstelle entwickelt, die diesen Anwendungsfall abbilden soll und muss.

Da wir diesen Mechanismus als grundsätzlich relevant erachten, soll das im besten Fall nicht über ein dynamisches Attribut umgesetzt werden. Das würde außerdem zusätzlichen Aufwand und Logik für die Abwärtskompatibilität mit sich bringen, sofern das irgendwann allgemeingültig definiert werden sollte. Unser Ziel ist eine standardisierte Lösung in den Ergebnisdaten.

#### 2. Referenzierung über Datensatznummern

Es wurde die Möglichkeit diskutiert, Referenzen über die Datensatznummern herzustellen. Da die HUSST Datensätze allerdings auf der Ebene des Warenkorbs definiert sind und ein Warenkorb mehrere Transaktionen enthalten kann, ist eine eindeutige Referenzierung über die Datensatznummer nicht möglich.

Stattdessen erfolgt die Referenzierung über die `BelegNr` des Produkts innerhalb der Transaktion. Analog dazu referenzieren wir beim Warenkorb ebenfalls auf die `BelegNr` und nicht auf die Datensatznummer, um hier mit dem Produkt gleich zu bleiben.